### PR TITLE
feat(search): 全文検索 + Cmd+P quick switcher (closes #3)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,16 @@
 {
   "name": "chrome-memo-app",
-  "version": "1.0.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chrome-memo-app",
-      "version": "1.0.0",
+      "version": "1.4.0",
       "dependencies": {
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
+        "fuse.js": "^7.3.0",
         "lucide-react": "^0.312.0",
         "mermaid": "^10.7.0",
         "react": "^18.2.0",
@@ -2444,6 +2445,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/fuse.js": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/fuse.js/-/fuse.js-7.3.0.tgz",
+      "integrity": "sha512-plz8RVjfcDedTGfVngWH1jmJvBvAwi1v2jecfDerbEnMcmOYUEEwKFTHbNoCiYyzaK2Ws8lABkTCcRSqCY1q4w==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/krisk"
       }
     },
     "node_modules/gensync": {

--- a/package.json
+++ b/package.json
@@ -9,16 +9,17 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
-    "tailwind-merge": "^2.2.0",
+    "fuse.js": "^7.3.0",
     "lucide-react": "^0.312.0",
+    "mermaid": "^10.7.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-markdown": "^9.0.1",
-    "remark-gfm": "^4.0.0",
     "rehype-raw": "^7.0.0",
-    "mermaid": "^10.7.0"
+    "remark-gfm": "^4.0.0",
+    "tailwind-merge": "^2.2.0"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.260",

--- a/src/components/memo-list.tsx
+++ b/src/components/memo-list.tsx
@@ -1,10 +1,12 @@
-import { useState } from "react"
-import { Trash2, Edit2, Plus, Search, FileText, Clock, ExternalLink, AlertCircle } from "lucide-react"
+import { useEffect, useRef, useState } from "react"
+import { Trash2, Edit2, Plus, Search, FileText, Clock, ExternalLink, AlertCircle, Command } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { RichEditor } from "@/components/rich-editor"
 import { MarkdownRenderer } from "@/components/markdown-renderer"
+import { QuickSwitcher } from "@/components/quick-switcher"
 import { useMemos, type Memo } from "@/hooks/use-chrome-storage"
+import { useQuickSwitcher } from "@/hooks/use-quick-switcher"
 import { useI18n } from "@/lib/i18n"
 import { cn } from "@/lib/utils"
 
@@ -84,6 +86,7 @@ function MemoItem({ memo, isSelected, isOld, onSelect, onEdit, onDelete }: MemoI
 
   return (
     <div
+      data-memo-id={memo.id}
       className={cn(
         "p-3 rounded-lg cursor-pointer transition-colors border group",
         isSelected
@@ -169,6 +172,32 @@ export function MemoList() {
   const [editingId, setEditingId] = useState<string | null>(null)
   const [isCreating, setIsCreating] = useState(false)
   const [searchQuery, setSearchQuery] = useState("")
+  const quickSwitcher = useQuickSwitcher()
+  const listContainerRef = useRef<HTMLDivElement | null>(null)
+  const pendingScrollRef = useRef<string | null>(null)
+
+  // When the user picks a memo from the quick switcher, leave any in-flight
+  // editor view and select the chosen memo. The list view will then scroll
+  // it into view via the effect below.
+  const handleQuickSelect = (memoId: string) => {
+    setIsCreating(false)
+    setEditingId(null)
+    setSelectedId(memoId)
+    pendingScrollRef.current = memoId
+  }
+
+  useEffect(() => {
+    const target = pendingScrollRef.current
+    if (!target) return
+    const container = listContainerRef.current
+    if (!container) return
+    const el = container.querySelector<HTMLElement>(`[data-memo-id="${target}"]`)
+    if (el) {
+      el.scrollIntoView({ behavior: "smooth", block: "nearest" })
+      pendingScrollRef.current = null
+    }
+  }, [selectedId, memos, isCreating, editingId])
+
   const storageInfo = getStorageInfo()
   const oldestMemos = [...memos]
     .sort((a, b) => a.updatedAt - b.updatedAt)
@@ -204,52 +233,68 @@ export function MemoList() {
     )
   }
 
+  const switcher = (
+    <QuickSwitcher
+      isOpen={quickSwitcher.isOpen}
+      memos={memos}
+      onClose={quickSwitcher.close}
+      onSelect={handleQuickSelect}
+    />
+  )
+
   if (isCreating) {
     return (
-      <Card className="h-full overflow-hidden flex flex-col">
-        <CardHeader className="pb-3 shrink-0">
-          <div className="flex items-center justify-between">
-            <CardTitle className="text-lg flex items-center gap-2">
-              <Plus className="h-4 w-4" />
-              {t("newMemo")}
-            </CardTitle>
-            <MermaidLink />
-          </div>
-        </CardHeader>
-        <CardContent className="flex-1 overflow-auto pt-4">
-          <MemoEditor
-            onSave={handleCreate}
-            onCancel={() => setIsCreating(false)}
-          />
-        </CardContent>
-      </Card>
+      <>
+        <Card className="h-full overflow-hidden flex flex-col">
+          <CardHeader className="pb-3 shrink-0">
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-lg flex items-center gap-2">
+                <Plus className="h-4 w-4" />
+                {t("newMemo")}
+              </CardTitle>
+              <MermaidLink />
+            </div>
+          </CardHeader>
+          <CardContent className="flex-1 overflow-auto pt-4">
+            <MemoEditor
+              onSave={handleCreate}
+              onCancel={() => setIsCreating(false)}
+            />
+          </CardContent>
+        </Card>
+        {switcher}
+      </>
     )
   }
 
   if (editingId && editingMemo) {
     return (
-      <Card className="h-full overflow-hidden flex flex-col">
-        <CardHeader className="pb-3 shrink-0">
-          <div className="flex items-center justify-between">
-            <CardTitle className="text-lg flex items-center gap-2">
-              <Edit2 className="h-4 w-4" />
-              {t("editMemo")}
-            </CardTitle>
-            <MermaidLink />
-          </div>
-        </CardHeader>
-        <CardContent className="flex-1 overflow-auto pt-4">
-          <MemoEditor
-            memo={editingMemo}
-            onSave={handleUpdate}
-            onCancel={() => setEditingId(null)}
-          />
-        </CardContent>
-      </Card>
+      <>
+        <Card className="h-full overflow-hidden flex flex-col">
+          <CardHeader className="pb-3 shrink-0">
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-lg flex items-center gap-2">
+                <Edit2 className="h-4 w-4" />
+                {t("editMemo")}
+              </CardTitle>
+              <MermaidLink />
+            </div>
+          </CardHeader>
+          <CardContent className="flex-1 overflow-auto pt-4">
+            <MemoEditor
+              memo={editingMemo}
+              onSave={handleUpdate}
+              onCancel={() => setEditingId(null)}
+            />
+          </CardContent>
+        </Card>
+        {switcher}
+      </>
     )
   }
 
   return (
+    <>
     <div className="flex flex-col h-full gap-4">
       {/* Storage warning banner */}
       {storageInfo.isNearLimit && (
@@ -287,6 +332,16 @@ export function MemoList() {
             className="flex h-9 w-full rounded-md border border-input bg-background pl-9 pr-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
           />
         </div>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={quickSwitcher.open}
+          title={t("openQuickSearch")}
+          aria-label={t("openQuickSearch")}
+        >
+          <Command className="h-3.5 w-3.5 mr-1" />
+          <span className="text-xs">P</span>
+        </Button>
         <Button size="sm" onClick={() => setIsCreating(true)}>
           <Plus className="h-4 w-4 mr-1" />
           New
@@ -311,7 +366,7 @@ export function MemoList() {
           )}
         </div>
       ) : (
-        <div className="flex-1 overflow-auto space-y-2">
+        <div ref={listContainerRef} className="flex-1 overflow-auto space-y-2">
           {filteredMemos.map((memo) => (
             <MemoItem
               key={memo.id}
@@ -363,5 +418,7 @@ export function MemoList() {
         </Card>
       )}
     </div>
+    {switcher}
+    </>
   )
 }

--- a/src/components/quick-switcher.tsx
+++ b/src/components/quick-switcher.tsx
@@ -1,0 +1,220 @@
+import { useEffect, useMemo, useRef, useState } from "react"
+import Fuse, { type FuseResult } from "fuse.js"
+import { Search, FileText } from "lucide-react"
+import type { Memo } from "@/hooks/use-chrome-storage"
+import { useI18n } from "@/lib/i18n"
+import { cn } from "@/lib/utils"
+
+interface QuickSwitcherProps {
+  isOpen: boolean
+  memos: Memo[]
+  onClose: () => void
+  onSelect: (memoId: string) => void
+}
+
+// Strip basic markdown noise so previews and search look clean.
+function getPlainText(markdown: string): string {
+  return markdown
+    .replace(/```[\s\S]*?```/g, " ")
+    .replace(/`[^`]*`/g, " ")
+    .replace(/!\[[^\]]*\]\([^)]*\)/g, " ")
+    .replace(/\[([^\]]*)\]\([^)]*\)/g, "$1")
+    .replace(/[#*_~>`-]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+}
+
+const MAX_RESULTS = 50
+
+export function QuickSwitcher({ isOpen, memos, onClose, onSelect }: QuickSwitcherProps) {
+  const { t } = useI18n()
+  const [query, setQuery] = useState("")
+  const [activeIndex, setActiveIndex] = useState(0)
+  const inputRef = useRef<HTMLInputElement | null>(null)
+  const listRef = useRef<HTMLDivElement | null>(null)
+
+  // Build a Fuse index over title + plain-text body. We rebuild whenever
+  // the memo list changes; for typical memo counts (hundreds) this is cheap.
+  const fuse = useMemo(() => {
+    const docs = memos.map((m) => ({
+      id: m.id,
+      title: m.title || "",
+      body: getPlainText(m.content || ""),
+      updatedAt: m.updatedAt,
+      memo: m,
+    }))
+    return new Fuse(docs, {
+      keys: [
+        { name: "title", weight: 0.7 },
+        { name: "body", weight: 0.3 },
+      ],
+      // Substring + fuzzy. Fuse normalizes case by default.
+      // ignoreLocation lets matches anywhere in the field count equally,
+      // which is important for Japanese (no word boundaries).
+      includeMatches: true,
+      includeScore: true,
+      ignoreLocation: true,
+      threshold: 0.4,
+      minMatchCharLength: 1,
+    })
+  }, [memos])
+
+  // Compute results. Empty query -> show recent memos (most recently updated).
+  const results = useMemo<Array<{ memo: Memo; score?: number }>>(() => {
+    const trimmed = query.trim()
+    if (!trimmed) {
+      return [...memos]
+        .sort((a, b) => b.updatedAt - a.updatedAt)
+        .slice(0, MAX_RESULTS)
+        .map((memo) => ({ memo }))
+    }
+    const matches: FuseResult<{ memo: Memo }>[] = fuse.search(trimmed, {
+      limit: MAX_RESULTS,
+    }) as unknown as FuseResult<{ memo: Memo }>[]
+    return matches.map((m) => ({ memo: m.item.memo, score: m.score }))
+  }, [query, memos, fuse])
+
+  // Reset state whenever the modal opens; focus the input.
+  useEffect(() => {
+    if (!isOpen) return
+    setQuery("")
+    setActiveIndex(0)
+    // Defer focus to next tick so the element is mounted.
+    const id = window.setTimeout(() => inputRef.current?.focus(), 0)
+    return () => window.clearTimeout(id)
+  }, [isOpen])
+
+  // Clamp active index when results change.
+  useEffect(() => {
+    setActiveIndex((idx) => {
+      if (results.length === 0) return 0
+      if (idx >= results.length) return results.length - 1
+      return idx
+    })
+  }, [results])
+
+  // Scroll the active item into view as the user navigates.
+  useEffect(() => {
+    if (!isOpen) return
+    const list = listRef.current
+    if (!list) return
+    const el = list.querySelector<HTMLElement>(`[data-qs-index="${activeIndex}"]`)
+    if (el) {
+      el.scrollIntoView({ block: "nearest" })
+    }
+  }, [activeIndex, isOpen])
+
+  if (!isOpen) return null
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDivElement>) => {
+    if (e.key === "Escape") {
+      e.preventDefault()
+      onClose()
+      return
+    }
+    if (e.key === "ArrowDown") {
+      e.preventDefault()
+      setActiveIndex((i) => Math.min(results.length - 1, i + 1))
+      return
+    }
+    if (e.key === "ArrowUp") {
+      e.preventDefault()
+      setActiveIndex((i) => Math.max(0, i - 1))
+      return
+    }
+    if (e.key === "Enter") {
+      e.preventDefault()
+      const picked = results[activeIndex]
+      if (picked) {
+        onSelect(picked.memo.id)
+        onClose()
+      }
+    }
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label={t("quickSearch")}
+      className="fixed inset-0 z-50 flex items-start justify-center bg-black/40 backdrop-blur-sm pt-[10vh] px-4"
+      onClick={onClose}
+      onKeyDown={handleKeyDown}
+    >
+      <div
+        className="w-full max-w-xl bg-popover text-popover-foreground border rounded-lg shadow-lg overflow-hidden"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center gap-2 border-b px-3 py-2">
+          <Search className="h-4 w-4 text-muted-foreground shrink-0" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={t("quickSearchPlaceholder")}
+            aria-label={t("quickSearchPlaceholder")}
+            className="flex-1 bg-transparent border-0 outline-none text-sm placeholder:text-muted-foreground"
+          />
+          <kbd className="hidden sm:inline px-1.5 py-0.5 bg-muted text-muted-foreground rounded text-[10px]">
+            Esc
+          </kbd>
+        </div>
+
+        <div ref={listRef} className="max-h-[50vh] overflow-auto">
+          {memos.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-10 text-muted-foreground gap-2">
+              <FileText className="h-8 w-8 opacity-50" />
+              <p className="text-sm">{t("quickSearchEmpty")}</p>
+            </div>
+          ) : results.length === 0 ? (
+            <div className="flex flex-col items-center justify-center py-10 text-muted-foreground gap-2">
+              <Search className="h-8 w-8 opacity-50" />
+              <p className="text-sm">{t("quickSearchNoResults")}</p>
+            </div>
+          ) : (
+            results.map((r, i) => {
+              const memo = r.memo
+              const preview = getPlainText(memo.content)
+              return (
+                <button
+                  type="button"
+                  key={memo.id}
+                  data-qs-index={i}
+                  onMouseEnter={() => setActiveIndex(i)}
+                  onClick={() => {
+                    onSelect(memo.id)
+                    onClose()
+                  }}
+                  className={cn(
+                    "w-full text-left px-3 py-2 flex flex-col gap-0.5 border-l-2 transition-colors",
+                    i === activeIndex
+                      ? "bg-accent border-primary"
+                      : "border-transparent hover:bg-muted",
+                  )}
+                >
+                  <span className="text-sm font-medium truncate">
+                    {memo.title || "Untitled"}
+                  </span>
+                  {preview && (
+                    <span className="text-xs text-muted-foreground line-clamp-1">
+                      {preview}
+                    </span>
+                  )}
+                </button>
+              )
+            })
+          )}
+        </div>
+
+        <div className="border-t px-3 py-1.5 text-[11px] text-muted-foreground flex items-center justify-between">
+          <span>{t("quickSearchHint")}</span>
+          <span className="hidden sm:inline">
+            <kbd className="px-1 py-0.5 bg-muted rounded">↑↓</kbd>{" "}
+            <kbd className="px-1 py-0.5 bg-muted rounded">Enter</kbd>
+          </span>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/hooks/use-quick-switcher.ts
+++ b/src/hooks/use-quick-switcher.ts
@@ -1,0 +1,57 @@
+import { useCallback, useEffect, useState } from "react"
+
+/**
+ * Cmd/Ctrl+P (and Cmd/Ctrl+K) opens a "quick switcher" / full-text search modal.
+ *
+ * Returns:
+ * - `isOpen`: whether the modal is currently open
+ * - `open()`: imperatively open the modal
+ * - `close()`: imperatively close the modal
+ * - `toggle()`: toggle open state
+ *
+ * The hook also dispatches and listens for a `colason:open-quick-search`
+ * CustomEvent so that other parts of the app (e.g. a button in the chrome)
+ * can request the modal without holding a direct reference to this hook.
+ */
+export function useQuickSwitcher() {
+  const [isOpen, setIsOpen] = useState(false)
+
+  const open = useCallback(() => setIsOpen(true), [])
+  const close = useCallback(() => setIsOpen(false), [])
+  const toggle = useCallback(() => setIsOpen((v) => !v), [])
+
+  // Global keyboard shortcut: Cmd/Ctrl + P (and Cmd/Ctrl + K as a fallback,
+  // since browsers may intercept Cmd+P for Print).
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      const isCmd = e.metaKey || e.ctrlKey
+      if (!isCmd) return
+      const key = e.key.toLowerCase()
+      if (key !== "p" && key !== "k") return
+
+      // Cmd+P is normally the browser's Print shortcut. We hijack it here
+      // because the Chrome extension popup and the PWA standalone window
+      // do not need print, and users expect Notion / VSCode style behavior.
+      e.preventDefault()
+      e.stopPropagation()
+      setIsOpen((prev) => !prev)
+    }
+    window.addEventListener("keydown", handler, true)
+    return () => window.removeEventListener("keydown", handler, true)
+  }, [])
+
+  // External trigger: any code can do
+  //   window.dispatchEvent(new CustomEvent("colason:open-quick-search"))
+  useEffect(() => {
+    const onOpen = () => setIsOpen(true)
+    const onClose = () => setIsOpen(false)
+    window.addEventListener("colason:open-quick-search", onOpen)
+    window.addEventListener("colason:close-quick-search", onClose)
+    return () => {
+      window.removeEventListener("colason:open-quick-search", onOpen)
+      window.removeEventListener("colason:close-quick-search", onClose)
+    }
+  }, [])
+
+  return { isOpen, open, close, toggle }
+}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -86,6 +86,14 @@ const translations = {
     storageOverLimit: "Storage limit exceeded!",
     storageUsage: "Storage usage",
     deleteOldMemos: "Consider deleting old memos to free up space.",
+
+    // Quick Switcher / Full-text Search
+    quickSearch: "Quick search",
+    quickSearchPlaceholder: "Search all memos...",
+    quickSearchHint: "Type to search title and body. Press Esc to close.",
+    quickSearchEmpty: "No memos to search yet.",
+    quickSearchNoResults: "No matching memos.",
+    openQuickSearch: "Open quick search",
   },
   ja: {
     // App
@@ -170,6 +178,14 @@ const translations = {
     storageOverLimit: "ストレージ容量が上限を超えました！",
     storageUsage: "使用量",
     deleteOldMemos: "古いメモを削除して容量を確保してください。",
+
+    // Quick Switcher / Full-text Search
+    quickSearch: "クイック検索",
+    quickSearchPlaceholder: "すべてのメモから検索...",
+    quickSearchHint: "タイトルと本文を検索します。Escで閉じます。",
+    quickSearchEmpty: "検索可能なメモがまだありません。",
+    quickSearchNoResults: "一致するメモがありません。",
+    openQuickSearch: "クイック検索を開く",
   },
 }
 


### PR DESCRIPTION
Closes #3

## Summary
- Fuse.js (^7.3) を導入し、title (weight 0.7) + body (weight 0.3) で fuzzy 全文 index を構築
- Cmd/Ctrl+P (Cmd/Ctrl+K も併用可) で QuickSwitcher modal を起動 — Notion/VSCode 風 incremental search
- 結果を ArrowUp/Down + Enter or click で選択 → 該当メモにジャンプ (scrollIntoView via `data-memo-id`)、preview pane が開く
- Empty query 時は更新日時降順で最新メモを表示 (quick switcher としても機能)

## 受け入れ基準 (Issue #3)
- [x] 全メモを title + body で全文 index (Fuse.js)
- [x] Cmd+P で modal 起動、incremental search
- [x] 結果クリックで該当メモにジャンプ
- [x] 大文字小文字無視 (Fuse 既定) / 日本語対応 (`ignoreLocation: true` + `minMatchCharLength: 1`)

## 設計メモ
- ライブラリ選定: Lunr.js は word-tokenizer 前提で日本語が苦手。Fuse.js は文字 n-gram 系の fuzzy なので日本語でも実用的。サイズも軽量。
- Cmd+P は通常ブラウザの Print。Chrome 拡張 popup / PWA standalone では print 不要なので意図的に hijack。Fallback で Cmd+K も bind。
- `useQuickSwitcher` hook が global keydown listener を保持し、`colason:open-quick-search` CustomEvent も受信 (今後 PWA titlebar からも起動できるように)
- Modal は `<QuickSwitcher>` 単一 component。`isOpen=false` のとき null を返すので overhead ほぼ無し。
- Index は `useMemo` で memos が変わるたびに再構築。数百〜数千件想定なので問題なし。

## 並行 PR との関係
- PR #8 (Web Window PWA) と同じく `src/components/memo-list.tsx` に手を入れているため merge 時に conflict 確実。
- `web/src/App.tsx` (PR #8) は `src/components/memo-list.tsx` を import するだけなので、PR #8 マージ後は web 側にも自動的に Cmd+P が effective になる (追加実装不要)。

## Test plan
- [ ] `npm run build` 成功 (extension popup) — ローカル確認済
- [ ] `npx tsc --noEmit` typecheck 成功 — ローカル確認済
- [ ] popup を開いて Cmd+P で modal 起動 → タイトル/本文どちらも検索ヒット
- [ ] 日本語 (例: 「メモ」) で検索ヒット
- [ ] 結果クリック → 該当メモがハイライト + scrollIntoView
- [ ] Esc / 背景クリックで modal が閉じる
- [ ] Arrow keys でリスト navigate, Enter で選択

## Out of scope
- Hit highlighting (matched substring の visual highlight) は将来作業
- Tag / date filter
- 検索履歴の永続化