### PR TITLE
feat(import-export): Markdown / JSON import + export (closes #5)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,17 @@
 {
   "name": "chrome-memo-app",
-  "version": "1.0.0",
+  "version": "1.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "chrome-memo-app",
-      "version": "1.0.0",
+      "version": "1.4.0",
       "dependencies": {
+        "@types/jszip": "^3.4.0",
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
+        "jszip": "^3.10.1",
         "lucide-react": "^0.312.0",
         "mermaid": "^10.7.0",
         "react": "^18.2.0",
@@ -1261,6 +1263,15 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/@types/jszip": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/@types/jszip/-/jszip-3.4.0.tgz",
+      "integrity": "sha512-GFHqtQQP3R4NNuvZH3hNCYD0NbyBZ42bkN7kO3NDrU/SnvIZWMS8Bp38XCsRKBT5BXvgm0y1zqpZWp/ZkRzBzg==",
+      "license": "MIT",
+      "dependencies": {
+        "jszip": "*"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "3.0.15",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-3.0.15.tgz",
@@ -1651,6 +1662,12 @@
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
       "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
     },
     "node_modules/cose-base": {
@@ -2666,6 +2683,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
+      "license": "MIT"
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
@@ -2799,6 +2828,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -2839,6 +2874,18 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/jszip": {
+      "version": "3.10.1",
+      "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
+      "integrity": "sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==",
+      "license": "(MIT OR GPL-3.0-or-later)",
+      "dependencies": {
+        "lie": "~3.3.0",
+        "pako": "~1.0.2",
+        "readable-stream": "~2.3.6",
+        "setimmediate": "^1.0.5"
       }
     },
     "node_modules/katex": {
@@ -2885,6 +2932,15 @@
       "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
       "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
       "license": "MIT"
+    },
+    "node_modules/lie": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
+      "integrity": "sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
     },
     "node_modules/lilconfig": {
       "version": "3.1.3",
@@ -9089,6 +9145,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pako": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+      "integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
+      "license": "(MIT AND Zlib)"
+    },
     "node_modules/parse-entities": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
@@ -9330,6 +9392,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "license": "MIT"
+    },
     "node_modules/property-information": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
@@ -9440,6 +9508,21 @@
       "license": "MIT",
       "dependencies": {
         "pify": "^2.3.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "license": "MIT",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
       }
     },
     "node_modules/readdirp": {
@@ -10192,6 +10275,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -10217,6 +10306,12 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/setimmediate": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
+      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
+      "license": "MIT"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -10235,6 +10330,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
       }
     },
     "node_modules/stringify-entities": {
@@ -10665,7 +10769,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/uuid": {

--- a/package.json
+++ b/package.json
@@ -9,16 +9,18 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
+    "@types/jszip": "^3.4.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
-    "tailwind-merge": "^2.2.0",
+    "jszip": "^3.10.1",
     "lucide-react": "^0.312.0",
+    "mermaid": "^10.7.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-markdown": "^9.0.1",
-    "remark-gfm": "^4.0.0",
     "rehype-raw": "^7.0.0",
-    "mermaid": "^10.7.0"
+    "remark-gfm": "^4.0.0",
+    "tailwind-merge": "^2.2.0"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.260",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Settings } from "lucide-react"
 import { ThemeProvider } from "@/components/theme-provider"
 import { ThemeToggle } from "@/components/theme-toggle"
 import { MemoList } from "@/components/memo-list"
+import { ImportExportPanel } from "@/components/import-export-panel"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { I18nProvider, useI18n } from "@/lib/i18n"
 
@@ -35,6 +36,11 @@ function AppContent() {
             <div>
               <h2 className="text-lg font-semibold mb-4">{t("appearance")}</h2>
               <ThemeToggle />
+            </div>
+
+            <div className="pt-4 border-t">
+              <h2 className="text-lg font-semibold mb-4">{t("importExport")}</h2>
+              <ImportExportPanel />
             </div>
 
             <div className="pt-4 border-t">

--- a/src/components/import-export-panel.tsx
+++ b/src/components/import-export-panel.tsx
@@ -1,0 +1,178 @@
+import { useRef, useState } from "react"
+import { Download, FileJson, FileArchive, Upload, AlertCircle, CheckCircle2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useMemos } from "@/hooks/use-chrome-storage"
+import {
+  buildJsonExport,
+  buildMarkdownZipExport,
+  importFromFile,
+  triggerDownload,
+} from "@/lib/import-export"
+import { useI18n } from "@/lib/i18n"
+
+type Status =
+  | { kind: "idle" }
+  | { kind: "working"; message: string }
+  | { kind: "success"; message: string }
+  | { kind: "error"; message: string }
+
+function formatStamp(now: Date): string {
+  const pad = (n: number) => String(n).padStart(2, "0")
+  return (
+    `${now.getFullYear()}` +
+    `${pad(now.getMonth() + 1)}` +
+    `${pad(now.getDate())}` +
+    `-` +
+    `${pad(now.getHours())}` +
+    `${pad(now.getMinutes())}`
+  )
+}
+
+export function ImportExportPanel() {
+  const { t } = useI18n()
+  const { memos, mergeMemos } = useMemos()
+  const [status, setStatus] = useState<Status>({ kind: "idle" })
+  const fileInputRef = useRef<HTMLInputElement | null>(null)
+
+  const handleExportJson = () => {
+    try {
+      const blob = buildJsonExport(memos)
+      triggerDownload(blob, `colason-memos-${formatStamp(new Date())}.json`)
+      setStatus({
+        kind: "success",
+        message: t("exportSuccessJson").replace("{count}", String(memos.length)),
+      })
+    } catch (e) {
+      setStatus({ kind: "error", message: e instanceof Error ? e.message : String(e) })
+    }
+  }
+
+  const handleExportZip = async () => {
+    setStatus({ kind: "working", message: t("exporting") })
+    try {
+      const blob = await buildMarkdownZipExport(memos)
+      triggerDownload(blob, `colason-memos-${formatStamp(new Date())}.zip`)
+      setStatus({
+        kind: "success",
+        message: t("exportSuccessZip").replace("{count}", String(memos.length)),
+      })
+    } catch (e) {
+      setStatus({ kind: "error", message: e instanceof Error ? e.message : String(e) })
+    }
+  }
+
+  const handlePickFiles = () => {
+    fileInputRef.current?.click()
+  }
+
+  const handleFiles = async (files: FileList | null) => {
+    if (!files || files.length === 0) return
+    setStatus({ kind: "working", message: t("importing") })
+    try {
+      const all = []
+      const errs = []
+      for (const file of Array.from(files)) {
+        const res = await importFromFile(file)
+        all.push(...res.memos)
+        errs.push(...res.errors)
+      }
+      if (all.length === 0 && errs.length > 0) {
+        setStatus({
+          kind: "error",
+          message: `${t("importFailed")}: ${errs[0]?.message ?? "unknown"}`,
+        })
+        return
+      }
+      const summary = mergeMemos(all)
+      const baseMsg = t("importSuccess")
+        .replace("{added}", String(summary.added))
+        .replace("{updated}", String(summary.updated))
+        .replace("{skipped}", String(summary.skipped))
+      const tail = errs.length > 0 ? ` (${errs.length} ${t("importErrorsSuffix")})` : ""
+      setStatus({ kind: "success", message: baseMsg + tail })
+    } catch (e) {
+      setStatus({ kind: "error", message: e instanceof Error ? e.message : String(e) })
+    } finally {
+      if (fileInputRef.current) fileInputRef.current.value = ""
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Download className="h-4 w-4 text-muted-foreground" />
+        <h3 className="text-sm font-medium">{t("exportSection")}</h3>
+      </div>
+      <p className="text-xs text-muted-foreground">{t("exportHint")}</p>
+      <div className="flex flex-wrap gap-2">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={handleExportJson}
+          disabled={memos.length === 0 || status.kind === "working"}
+        >
+          <FileJson className="h-4 w-4 mr-2" />
+          {t("exportJson")}
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={handleExportZip}
+          disabled={memos.length === 0 || status.kind === "working"}
+        >
+          <FileArchive className="h-4 w-4 mr-2" />
+          {t("exportMarkdownZip")}
+        </Button>
+      </div>
+
+      <div className="pt-4 border-t flex items-center gap-2">
+        <Upload className="h-4 w-4 text-muted-foreground" />
+        <h3 className="text-sm font-medium">{t("importSection")}</h3>
+      </div>
+      <p className="text-xs text-muted-foreground">{t("importHint")}</p>
+      <div>
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          accept=".json,.md,.markdown,.txt,.zip,application/json,text/markdown,application/zip"
+          className="hidden"
+          onChange={(e) => handleFiles(e.target.files)}
+        />
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={handlePickFiles}
+          disabled={status.kind === "working"}
+        >
+          <Upload className="h-4 w-4 mr-2" />
+          {t("chooseFiles")}
+        </Button>
+      </div>
+
+      {status.kind !== "idle" && (
+        <div
+          role="status"
+          className={
+            "text-xs flex items-start gap-2 rounded-md border p-2 " +
+            (status.kind === "error"
+              ? "border-destructive/50 text-destructive"
+              : status.kind === "success"
+                ? "border-green-600/40 text-green-700 dark:text-green-400"
+                : "border-border text-muted-foreground")
+          }
+        >
+          {status.kind === "error" ? (
+            <AlertCircle className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+          ) : status.kind === "success" ? (
+            <CheckCircle2 className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+          ) : null}
+          <span>{status.message}</span>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/hooks/use-chrome-storage.ts
+++ b/src/hooks/use-chrome-storage.ts
@@ -53,6 +53,10 @@ export interface Memo {
   content: string
   createdAt: number
   updatedAt: number
+  /** Optional tags. May be merged with PR #10 once it lands. */
+  tags?: string[]
+  /** Optional category (free-form). */
+  category?: string
 }
 
 export function useMemos() {
@@ -84,6 +88,48 @@ export function useMemos() {
     setMemos((prev) => prev.filter((memo) => memo.id !== id))
   }, [setMemos])
 
+  /**
+   * Replace the full memo list. Used by import flows.
+   */
+  const replaceMemos = useCallback((next: Memo[]) => {
+    setMemos(next)
+  }, [setMemos])
+
+  /**
+   * Merge incoming memos using id (preferred) or title fallback.
+   * For collisions, the entry with the newer `updatedAt` wins.
+   * Returns counts so the caller can show a result toast.
+   */
+  const mergeMemos = useCallback((incoming: Memo[]) => {
+    let added = 0
+    let updated = 0
+    let skipped = 0
+
+    setMemos((prev) => {
+      const byId = new Map<string, Memo>()
+      prev.forEach((m) => byId.set(m.id, m))
+
+      for (const candidate of incoming) {
+        const existing = byId.get(candidate.id)
+        if (!existing) {
+          byId.set(candidate.id, candidate)
+          added++
+          continue
+        }
+        if (candidate.updatedAt > existing.updatedAt) {
+          byId.set(candidate.id, { ...existing, ...candidate })
+          updated++
+        } else {
+          skipped++
+        }
+      }
+
+      return Array.from(byId.values()).sort((a, b) => b.updatedAt - a.updatedAt)
+    })
+
+    return { added, updated, skipped }
+  }, [setMemos])
+
   const getStorageInfo = useCallback(() => {
     const sizeInBytes = calculateStorageSize(memos)
     const maxSize = 8192 // 8KB limit for chrome.storage.sync per key
@@ -101,5 +147,14 @@ export function useMemos() {
     }
   }, [memos])
 
-  return { memos, addMemo, updateMemo, deleteMemo, isLoading, getStorageInfo }
+  return {
+    memos,
+    addMemo,
+    updateMemo,
+    deleteMemo,
+    replaceMemos,
+    mergeMemos,
+    isLoading,
+    getStorageInfo,
+  }
 }

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -86,6 +86,23 @@ const translations = {
     storageOverLimit: "Storage limit exceeded!",
     storageUsage: "Storage usage",
     deleteOldMemos: "Consider deleting old memos to free up space.",
+
+    // Import / Export
+    importExport: "Import / Export",
+    exportSection: "Export",
+    importSection: "Import",
+    exportHint: "Download all memos as JSON, or as a zip of individual Markdown files (with frontmatter).",
+    importHint: "Pick .json / .md / .markdown / .txt / .zip files. Existing memos with the same id are kept if they are newer.",
+    exportJson: "Export JSON",
+    exportMarkdownZip: "Export Markdown (zip)",
+    chooseFiles: "Choose files…",
+    exporting: "Preparing download…",
+    importing: "Importing…",
+    exportSuccessJson: "Exported {count} memos as JSON.",
+    exportSuccessZip: "Exported {count} memos as Markdown zip.",
+    importSuccess: "Imported: {added} added, {updated} updated, {skipped} skipped.",
+    importFailed: "Import failed",
+    importErrorsSuffix: "errors",
   },
   ja: {
     // App
@@ -170,6 +187,23 @@ const translations = {
     storageOverLimit: "ストレージ容量が上限を超えました！",
     storageUsage: "使用量",
     deleteOldMemos: "古いメモを削除して容量を確保してください。",
+
+    // Import / Export
+    importExport: "インポート / エクスポート",
+    exportSection: "エクスポート",
+    importSection: "インポート",
+    exportHint: "全メモを JSON、または個別 Markdown ファイル (frontmatter 付き) の zip としてダウンロードします。",
+    importHint: ".json / .md / .markdown / .txt / .zip を選択してください。同じ id のメモは新しい方が残ります。",
+    exportJson: "JSON でエクスポート",
+    exportMarkdownZip: "Markdown zip でエクスポート",
+    chooseFiles: "ファイルを選択…",
+    exporting: "ダウンロード準備中…",
+    importing: "インポート中…",
+    exportSuccessJson: "{count} 件のメモを JSON でエクスポートしました。",
+    exportSuccessZip: "{count} 件のメモを Markdown zip でエクスポートしました。",
+    importSuccess: "インポート完了: 追加 {added} / 更新 {updated} / スキップ {skipped}",
+    importFailed: "インポート失敗",
+    importErrorsSuffix: "件の警告",
   },
 }
 

--- a/src/lib/import-export.ts
+++ b/src/lib/import-export.ts
@@ -1,0 +1,357 @@
+import JSZip from "jszip"
+import type { Memo } from "@/hooks/use-chrome-storage"
+
+/**
+ * Schema version for the JSON export format. Bump when the on-disk shape
+ * changes in a non-backwards-compatible way.
+ */
+export const EXPORT_SCHEMA_VERSION = 1
+
+export interface ExportPayload {
+  schema: number
+  exportedAt: number
+  appName: "Colason"
+  memos: Memo[]
+}
+
+/**
+ * Sanitize a string so it can be used as a filename across OS.
+ * Falls back to "untitled" when nothing usable is left.
+ */
+export function safeFileName(input: string): string {
+  const trimmed = (input || "").trim()
+  // Strip control chars + chars not allowed on Windows + path separators.
+  const cleaned = trimmed
+    .replace(/[\u0000-\u001f<>:"/\\|?*]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+  if (!cleaned) return "untitled"
+  // Cap length so the .md suffix + dedup index still fit in 255 bytes.
+  return cleaned.slice(0, 80)
+}
+
+/**
+ * Serialize a Memo to a Markdown file with YAML-ish frontmatter.
+ * tags / category are preserved as frontmatter so round-trips with
+ * Obsidian / VSCode keep metadata intact.
+ */
+export function memoToMarkdown(memo: Memo): string {
+  const fm: string[] = ["---"]
+  fm.push(`id: ${memo.id}`)
+  if (memo.title) fm.push(`title: ${escapeYamlString(memo.title)}`)
+  fm.push(`createdAt: ${new Date(memo.createdAt).toISOString()}`)
+  fm.push(`updatedAt: ${new Date(memo.updatedAt).toISOString()}`)
+  if (memo.tags && memo.tags.length > 0) {
+    const list = memo.tags.map((t) => escapeYamlString(t)).join(", ")
+    fm.push(`tags: [${list}]`)
+  }
+  if (memo.category) fm.push(`category: ${escapeYamlString(memo.category)}`)
+  fm.push("---")
+  fm.push("")
+  fm.push(memo.content || "")
+  return fm.join("\n")
+}
+
+function escapeYamlString(input: string): string {
+  // Quote when the value contains characters with YAML meaning.
+  if (/[:#\-\[\]\{\},&*?|<>=!%@`"\n']/.test(input)) {
+    return `"${input.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`
+  }
+  return input
+}
+
+interface ParsedFrontmatter {
+  data: Record<string, string | string[]>
+  body: string
+}
+
+/**
+ * Parse the leading `---\n…\n---` YAML-ish block. Only the small subset
+ * we emit ourselves is supported (scalar strings + inline arrays).
+ */
+export function parseFrontmatter(source: string): ParsedFrontmatter {
+  const normalized = source.replace(/^\uFEFF/, "")
+  const match = /^---\r?\n([\s\S]*?)\r?\n---\r?\n?([\s\S]*)$/.exec(normalized)
+  if (!match) {
+    return { data: {}, body: normalized }
+  }
+  const block = match[1] ?? ""
+  const body = match[2] ?? ""
+  const data: Record<string, string | string[]> = {}
+  for (const rawLine of block.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith("#")) continue
+    const colon = line.indexOf(":")
+    if (colon === -1) continue
+    const key = line.slice(0, colon).trim()
+    const rawValue = line.slice(colon + 1).trim()
+    if (!key) continue
+    if (rawValue.startsWith("[") && rawValue.endsWith("]")) {
+      data[key] = rawValue
+        .slice(1, -1)
+        .split(",")
+        .map((s) => unquoteYaml(s.trim()))
+        .filter((s) => s.length > 0)
+    } else {
+      data[key] = unquoteYaml(rawValue)
+    }
+  }
+  return { data, body }
+}
+
+function unquoteYaml(input: string): string {
+  if (input.length >= 2) {
+    const first = input[0]
+    const last = input[input.length - 1]
+    if ((first === '"' && last === '"') || (first === "'" && last === "'")) {
+      return input.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, "\\")
+    }
+  }
+  return input
+}
+
+/**
+ * Try to coerce a frontmatter date into a unix-ms timestamp.
+ * Falls back to "now" so import never throws on weird inputs.
+ */
+function toTimestamp(value: string | string[] | undefined, fallback: number): number {
+  if (typeof value !== "string") return fallback
+  const ms = Date.parse(value)
+  if (Number.isFinite(ms)) return ms
+  const num = Number(value)
+  if (Number.isFinite(num) && num > 0) return num
+  return fallback
+}
+
+/**
+ * Convert a parsed Markdown document into a Memo. The fallback title is
+ * derived from the first heading or first non-empty line so notes from
+ * Obsidian / Notion still arrive with a usable title.
+ */
+export function markdownToMemo(source: string, fallbackTitle: string): Memo {
+  const { data, body } = parseFrontmatter(source)
+  const now = Date.now()
+  const createdAt = toTimestamp(data["createdAt"] ?? data["created"], now)
+  const updatedAt = toTimestamp(
+    data["updatedAt"] ?? data["updated"] ?? data["modified"],
+    createdAt,
+  )
+
+  const id =
+    (typeof data["id"] === "string" && data["id"]) || (crypto?.randomUUID?.() ?? `${now}-${Math.random()}`)
+
+  const title =
+    (typeof data["title"] === "string" && data["title"]) ||
+    extractTitleFromBody(body) ||
+    fallbackTitle
+
+  const tagsRaw = data["tags"]
+  const tags = Array.isArray(tagsRaw) ? tagsRaw : undefined
+
+  const category = typeof data["category"] === "string" ? data["category"] : undefined
+
+  const memo: Memo = {
+    id,
+    title: title.trim() || "Untitled",
+    content: body.replace(/^\s*\n/, ""),
+    createdAt,
+    updatedAt,
+  }
+  if (tags && tags.length > 0) memo.tags = tags
+  if (category) memo.category = category
+  return memo
+}
+
+function extractTitleFromBody(body: string): string | undefined {
+  for (const rawLine of body.split(/\r?\n/)) {
+    const line = rawLine.trim()
+    if (!line) continue
+    const heading = /^#{1,6}\s+(.*)$/.exec(line)
+    if (heading) return heading[1]
+    return line
+  }
+  return undefined
+}
+
+/**
+ * Build a JSON blob ready for download.
+ */
+export function buildJsonExport(memos: Memo[]): Blob {
+  const payload: ExportPayload = {
+    schema: EXPORT_SCHEMA_VERSION,
+    exportedAt: Date.now(),
+    appName: "Colason",
+    memos,
+  }
+  return new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" })
+}
+
+/**
+ * Build a Markdown zip archive. Each memo gets its own .md file. Filename
+ * collisions are handled by suffixing `(2)`, `(3)`, …
+ */
+export async function buildMarkdownZipExport(memos: Memo[]): Promise<Blob> {
+  const zip = new JSZip()
+  const used = new Map<string, number>()
+
+  for (const memo of memos) {
+    const base = safeFileName(memo.title || "untitled")
+    const count = used.get(base) ?? 0
+    used.set(base, count + 1)
+    const filename = count === 0 ? `${base}.md` : `${base} (${count + 1}).md`
+    zip.file(filename, memoToMarkdown(memo))
+  }
+
+  // Include the JSON export inside the zip too so power users get a
+  // full-fidelity backup in a single file.
+  zip.file(
+    "memos.json",
+    JSON.stringify(
+      {
+        schema: EXPORT_SCHEMA_VERSION,
+        exportedAt: Date.now(),
+        appName: "Colason",
+        memos,
+      } satisfies ExportPayload,
+      null,
+      2,
+    ),
+  )
+
+  return zip.generateAsync({ type: "blob" })
+}
+
+/**
+ * Trigger a file download in the browser.
+ */
+export function triggerDownload(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob)
+  const link = document.createElement("a")
+  link.href = url
+  link.download = filename
+  document.body.appendChild(link)
+  link.click()
+  link.remove()
+  // Defer revoke so Chrome has time to start the download.
+  setTimeout(() => URL.revokeObjectURL(url), 1000)
+}
+
+export interface ImportResult {
+  memos: Memo[]
+  /** files that could not be parsed (filename + reason) */
+  errors: Array<{ filename: string; message: string }>
+}
+
+/**
+ * Validate that an unknown payload looks like ExportPayload and extract memos.
+ */
+function memosFromJsonPayload(parsed: unknown, source: string): Memo[] {
+  if (Array.isArray(parsed)) {
+    return parsed.map((entry, idx) => coerceJsonMemo(entry, `${source}#${idx}`))
+  }
+  if (parsed && typeof parsed === "object" && "memos" in parsed) {
+    const list = (parsed as { memos: unknown }).memos
+    if (Array.isArray(list)) {
+      return list.map((entry, idx) => coerceJsonMemo(entry, `${source}#${idx}`))
+    }
+  }
+  throw new Error("Unrecognized JSON shape — expected { memos: [] } or an array")
+}
+
+function coerceJsonMemo(raw: unknown, where: string): Memo {
+  if (!raw || typeof raw !== "object") {
+    throw new Error(`Entry at ${where} is not an object`)
+  }
+  const r = raw as Record<string, unknown>
+  const now = Date.now()
+  const id =
+    typeof r["id"] === "string" && r["id"] ? r["id"] : crypto?.randomUUID?.() ?? `${now}-${Math.random()}`
+  const title = typeof r["title"] === "string" ? r["title"] : "Untitled"
+  const content = typeof r["content"] === "string" ? r["content"] : ""
+  const createdAt = typeof r["createdAt"] === "number" ? r["createdAt"] : now
+  const updatedAt = typeof r["updatedAt"] === "number" ? r["updatedAt"] : createdAt
+
+  const memo: Memo = { id, title, content, createdAt, updatedAt }
+
+  if (Array.isArray(r["tags"])) {
+    const tags = (r["tags"] as unknown[]).filter((t): t is string => typeof t === "string")
+    if (tags.length > 0) memo.tags = tags
+  }
+  if (typeof r["category"] === "string") {
+    memo.category = r["category"]
+  }
+  return memo
+}
+
+/**
+ * Import a single user-provided file. Detects type by extension.
+ */
+export async function importFromFile(file: File): Promise<ImportResult> {
+  const name = file.name.toLowerCase()
+  if (name.endsWith(".json")) {
+    return importJson(await file.text(), file.name)
+  }
+  if (name.endsWith(".md") || name.endsWith(".markdown") || name.endsWith(".txt")) {
+    return importMarkdownText(await file.text(), file.name)
+  }
+  if (name.endsWith(".zip")) {
+    return importZip(file)
+  }
+  return {
+    memos: [],
+    errors: [
+      {
+        filename: file.name,
+        message: "Unsupported file type — expected .json, .md, .markdown, .txt, or .zip",
+      },
+    ],
+  }
+}
+
+export function importJson(text: string, filename: string): ImportResult {
+  try {
+    const parsed = JSON.parse(text) as unknown
+    return { memos: memosFromJsonPayload(parsed, filename), errors: [] }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    return { memos: [], errors: [{ filename, message }] }
+  }
+}
+
+export function importMarkdownText(text: string, filename: string): ImportResult {
+  try {
+    const fallback = filename.replace(/\.(md|markdown|txt)$/i, "")
+    const memo = markdownToMemo(text, fallback || "Untitled")
+    return { memos: [memo], errors: [] }
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    return { memos: [], errors: [{ filename, message }] }
+  }
+}
+
+export async function importZip(file: File): Promise<ImportResult> {
+  const memos: Memo[] = []
+  const errors: ImportResult["errors"] = []
+  const zip = await JSZip.loadAsync(file)
+  const entries = Object.values(zip.files)
+  for (const entry of entries) {
+    if (entry.dir) continue
+    const name = entry.name
+    const lower = name.toLowerCase()
+    try {
+      if (lower.endsWith(".json")) {
+        const text = await entry.async("string")
+        memos.push(...memosFromJsonPayload(JSON.parse(text), name))
+        continue
+      }
+      if (lower.endsWith(".md") || lower.endsWith(".markdown") || lower.endsWith(".txt")) {
+        const text = await entry.async("string")
+        const fallback = name.split("/").pop()?.replace(/\.(md|markdown|txt)$/i, "") ?? "Untitled"
+        memos.push(markdownToMemo(text, fallback))
+      }
+    } catch (e) {
+      errors.push({ filename: name, message: e instanceof Error ? e.message : String(e) })
+    }
+  }
+  return { memos, errors }
+}


### PR DESCRIPTION
## Summary
- Settings ページに Import / Export パネルを追加 (closes #5)
- JSON エクスポート (schema versioned, full fidelity) + Markdown zip エクスポート (個別 .md + frontmatter + 同梱の memos.json)
- .json / .md / .markdown / .txt / .zip のインポートに対応 (multi-file 可)
- 重複検知は `id` を主キーに `updatedAt` 比較で newer wins、結果は added / updated / skipped を表示
- frontmatter で `id` / `createdAt` / `updatedAt` / `tags` / `category` を保持し Obsidian / Notion / VSCode との往復に耐える
- `Memo` 型に optional な `tags?: string[]` / `category?: string` を追加 (PR #10 とマージ予定)
- 依存追加: `jszip`

## Implementation notes
- `src/lib/import-export.ts` がコアロジック (純関数 + Blob 生成、テスト容易)
- `useMemos()` に `mergeMemos(incoming)` / `replaceMemos(next)` を追加
- 文字列 sanitization + ファイル名重複時 `(2)` suffix で OS 互換
- 既存の i18n / Button / lucide-react で一貫した UI

## Test plan
- [ ] `npm run build` 通過 (TypeScript strict + vite build)
- [ ] Settings タブで Export JSON → ファイル保存 → 中身が `{schema, exportedAt, memos:[...]}`
- [ ] Settings タブで Export Markdown (zip) → 中身に `*.md` + `memos.json`、frontmatter に tags が含まれる
- [ ] エクスポートした JSON / zip を別環境でインポート → メモが復元
- [ ] 同じメモを再 import → updated 0 / skipped N (timestamp が同じため)
- [ ] エクスポート後にメモを編集 → 旧 zip を再 import → skipped (incoming は古い)
- [ ] frontmatter なしの素の `.md` を import → 1 行目 / 1st heading が title になる
- [ ] 不正な JSON を入れると error メッセージが出る

## Related
- 並行 reviewing: PR #8 (PWA), PR #9 (search), PR #10 (tags)
- Memo.tags は PR #10 でも追加予定なので、マージ時は型を merge