### PR TITLE
feat(sync): Firestore + Google Sign-in でメモ同期 (closes #6)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist
 web-dist
 *.log
 .DS_Store
+web/.env
+web/.env.local

--- a/README.md
+++ b/README.md
@@ -53,10 +53,34 @@ For a real deployment, host `web-dist/` on any HTTPS static origin (Cloudflare P
 | `Cmd/Ctrl + I` | Italic |
 | `Cmd/Ctrl + K` | Link |
 
+## Cloud sync (PWA only)
+
+The PWA build supports optional Google Sign-in + Firestore sync. Memos stay device-local until you sign in; after sign-in they sync to Firestore under `colason_users/{uid}/memos/{memoId}`. Existing local memos are migrated once on first sign-in.
+
+The Chrome extension build is unaffected — it continues to use `chrome.storage.sync` only.
+
+### Setup
+
+1. Firebase Console → `yomi-note-app` project → **Project settings → Your apps → Add app → Web** → register an app named `colason`. Copy the config.
+2. `cp web/.env.example web/.env` and fill in `VITE_FIREBASE_API_KEY`, `VITE_FIREBASE_APP_ID`, etc.
+3. Firebase Console → **Authentication → Sign-in method** → enable **Google**. Add `localhost` and your prod domain to the authorized domains.
+4. Append the contents of `firestore.rules.colason` to the project's existing Firestore rules (yomi-note repo's `firestore.rules`) and re-deploy them. The block is additive and namespaced under `colason_users/`, so it does not affect yomi-note's existing collections.
+5. Rebuild the PWA: `npm run build:web`.
+
+If `VITE_FIREBASE_*` is not configured, the app silently runs in local-only mode (current behavior).
+
+### Tenancy / data isolation
+
+Colason data is fully namespaced — it never collides with yomi-note's own collections (`users`, `papers`, `terms`, `questions`, `reflections`, `feedbacks`, `drafts`). All reads/writes are gated by `request.auth.uid == uid` so other Google users cannot see your memos.
+
 ### Architecture notes
 
 - `src/` — shared UI (memo list, rich editor, markdown renderer, theme, i18n).
-- `src/hooks/use-chrome-storage.ts` — runtime-detects `chrome.storage.sync`; falls back to IndexedDB for the PWA build, then to `localStorage`.
+- `src/hooks/use-chrome-storage.ts` — Chrome extension build: `chrome.storage.sync` only.
+- `web/src/hooks/use-chrome-storage.ts` — PWA build override (selected via Vite alias): IndexedDB locally; Firestore + Google Sign-in when configured and signed-in.
+- `web/src/lib/firebase.ts` — lazy Firebase init (auth + Firestore with persistent local cache). Returns `null` when env is unset.
+- `web/src/lib/firestore-memos.ts` — CRUD + `onSnapshot` subscription against `colason_users/{uid}/memos`.
+- `web/src/lib/migration.ts` — one-time IndexedDB → Firestore migration on first sign-in (idempotent via `migrationCompletedAt` flag).
 - `src/lib/idb-store.ts` — minimal hand-written IndexedDB key-value store (no extra dep).
 - `web/index.html`, `web/src/App.tsx`, `web/src/main.tsx` — PWA entry, app shell with `display_override: window-controls-overlay`.
 - `web/public/manifest.webmanifest` — PWA manifest (standalone, WCO, icons, app shortcut).

--- a/firestore.rules.colason
+++ b/firestore.rules.colason
@@ -1,0 +1,16 @@
+// Colason (chrome_app_memo) Firestore security rules.
+//
+// This block must be merged into the yomi-note-app project's firestore.rules
+// (yomi-note repo). It is namespace-isolated from yomi-note's existing
+// collections (users / papers / terms / questions / reflections / feedbacks /
+// drafts) — Colason data lives only under `colason_users/{uid}`.
+//
+// Append the rules below inside `match /databases/{database}/documents { ... }`.
+
+match /colason_users/{uid} {
+  allow read, write: if request.auth != null && request.auth.uid == uid;
+
+  match /memos/{memoId} {
+    allow read, write: if request.auth != null && request.auth.uid == uid;
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "class-variance-authority": "^0.7.0",
         "clsx": "^2.1.0",
+        "firebase": "^12.12.1",
         "lucide-react": "^0.312.0",
         "mermaid": "^10.7.0",
         "react": "^18.2.0",
@@ -724,6 +725,648 @@
         "node": ">=12"
       }
     },
+    "node_modules/@firebase/ai": {
+      "version": "2.11.1",
+      "resolved": "https://registry.npmjs.org/@firebase/ai/-/ai-2.11.1.tgz",
+      "integrity": "sha512-WGTF81W3WBKJY+c7xqTzO15OGAkCAs8cpADqflAI0skhTZjIkhF0qyf55rq4Ctt6jKygkv99rPfMrjAHTgXaVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics": {
+      "version": "0.10.21",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics/-/analytics-0.10.21.tgz",
+      "integrity": "sha512-j2y2q65BlgLGB5Pwjhv/Jopw2X/TBTzvAtI5z/DSp56U4wBj7LfhBfzbdCtFPges+Wz0g55GdoawXibOH5jGng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-compat": {
+      "version": "0.2.27",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-compat/-/analytics-compat-0.2.27.tgz",
+      "integrity": "sha512-ZObpYpAxL6JfgH7GnvlDD0sbzGZ0o4nijV8skatV9ZX49hJtCYbFqaEcPYptT94rgX1KUoKEderC7/fa7hybtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/analytics": "0.10.21",
+        "@firebase/analytics-types": "0.8.3",
+        "@firebase/component": "0.7.2",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/analytics-types": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/analytics-types/-/analytics-types-0.8.3.tgz",
+      "integrity": "sha512-VrIp/d8iq2g501qO46uGz3hjbDb8xzYMrbu8Tp0ovzIzrvJZ2fvmj649gTjge/b7cCCcjT0H37g1gVtlNhnkbg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app": {
+      "version": "0.14.11",
+      "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.14.11.tgz",
+      "integrity": "sha512-yxADFW35LYkP8oSGobGsYIrI42I+GPCvKTNHx4meT9Yq3C950IVz1eANoBk822I9tbKv1wyv9P4Bv1G5TpucFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-check": {
+      "version": "0.11.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check/-/app-check-0.11.2.tgz",
+      "integrity": "sha512-jcXQVMHAQ5AEKzVD5C7s5fmAYeFOuN6lAJeNTgZK2B9aLnofWaJt8u1A8Idm8gpsBBYSaY3cVyeH5SWMOVPBLQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-compat": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-compat/-/app-check-compat-0.4.2.tgz",
+      "integrity": "sha512-M91NhxqbSkI0ChkJWy69blC+rPr6HEgaeRllddSaU1pQ/7IiegeCQM9pPDIgvWnwnBSzKhUHpe6ro/jhJ+cvzw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check": "0.11.2",
+        "@firebase/app-check-types": "0.5.3",
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/app-check-interop-types": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-interop-types/-/app-check-interop-types-0.3.3.tgz",
+      "integrity": "sha512-gAlxfPLT2j8bTI/qfe3ahl2I2YcBQ8cFIBdhAQA4I2f3TndcO+22YizyGYuttLHPQEpWkhmpFW60VCFEPg4g5A==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-check-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/app-check-types/-/app-check-types-0.5.3.tgz",
+      "integrity": "sha512-hyl5rKSj0QmwPdsAxrI5x1otDlByQ7bvNvVt8G/XPO2CSwE++rmSVf3VEhaeOR4J8ZFaF0Z0NDSmLejPweZ3ng==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/app-compat": {
+      "version": "0.5.11",
+      "resolved": "https://registry.npmjs.org/@firebase/app-compat/-/app-compat-0.5.11.tgz",
+      "integrity": "sha512-KaACDjXkK5VLpI01vEs592R7/8s5DjFdIXfKoR385ly1SmK3Tu+jMHCIB4MsiY5jsez6v7VlEX/3rJ90dVkHyA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app": "0.14.11",
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/app-types": {
+      "version": "0.9.4",
+      "resolved": "https://registry.npmjs.org/@firebase/app-types/-/app-types-0.9.4.tgz",
+      "integrity": "sha512-crX9TA5SVYZwLPG7/R16IsH8FLlgkPXjJUVhsVpHVDSqJiq3D/NuFTM5ctxGTExXAOeIn//69tQw47CPerM8MQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/logger": "0.5.0"
+      }
+    },
+    "node_modules/@firebase/auth-compat": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-compat/-/auth-compat-0.6.5.tgz",
+      "integrity": "sha512-IfVsafZ3QiXbsydXTP/XMI0wVYbJLI1rkb8Qqf03/h5FnL+upbbPOb+6Yj3RpcX+Y1iP5Uh18lxTHlXfbiyAow==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth": "1.13.0",
+        "@firebase/auth-types": "0.13.0",
+        "@firebase/component": "0.7.2",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/auth-compat/node_modules/@firebase/auth": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.0.tgz",
+      "integrity": "sha512-mKkSLNym3UbnnZ06dAmtqzp5EpPGCANGCZDJbkoR135aoUdKG6Aizwcnp29RzsQpwH0nmy5nay17Sfbsh9oY8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@firebase/auth-interop-types": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-interop-types/-/auth-interop-types-0.2.4.tgz",
+      "integrity": "sha512-JPgcXKCuO+CWqGDnigBtvo09HeBs5u/Ktc2GaFj2m01hLarbxthLNm7Fk8iOP1aqAtXV+fnnGj7U28xmk7IwVA==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/auth-types": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth-types/-/auth-types-0.13.0.tgz",
+      "integrity": "sha512-S/PuIjni0AQRLF+l9ck0YpsMOdE8GO2KU6ubmBB7P+7TJUCQDa3R1dlgYm9UzGbbePMZsp0xzB93f2b/CgxMOg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/component": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@firebase/component/-/component-0.7.2.tgz",
+      "integrity": "sha512-iyVDGc6Vjx7Rm0cAdccLH/NG6fADsgJak/XW9IA2lPf8AjIlsemOpFGKczYyPHxm4rnKdR8z6sK4+KEC7NwmEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/data-connect": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/@firebase/data-connect/-/data-connect-0.6.0.tgz",
+      "integrity": "sha512-OiugPRcdlhqXF97oR9CjVObILmsWU0dFUS0gXNYEe4bDfpW8pZmQ5GqhIPPtLWbT/0W2lMJJD7VILFMk+xuHPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/database": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@firebase/database/-/database-1.1.2.tgz",
+      "integrity": "sha512-lP96CMjMPy/+d1d9qaaHjHHdzdwvEOuyyLq9ehX89e2XMKwS1jHNzYBO+42bdSumuj5ukPbmnFtViZu8YOMT+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "faye-websocket": "0.11.4",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-compat": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@firebase/database-compat/-/database-compat-2.1.3.tgz",
+      "integrity": "sha512-GMyfWjD8mehjg/QpNkY/tl9G/MoeugPeg91n9D0atggxbWuKF/2KhVPHZDH+XmoP0EKYqMWYTtKxBsaBaNKLYQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/database": "1.1.2",
+        "@firebase/database-types": "1.0.19",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/database-types": {
+      "version": "1.0.19",
+      "resolved": "https://registry.npmjs.org/@firebase/database-types/-/database-types-1.0.19.tgz",
+      "integrity": "sha512-FqewjUZmV9LqFfuEnmgdcUpiOUz7qwLXxnm/H8BcMFEzQXtd1yyUDm8ex5VRad2nuTE+ahOuCjUAM/cyDncO+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-types": "0.9.4",
+        "@firebase/util": "1.15.0"
+      }
+    },
+    "node_modules/@firebase/firestore": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-4.14.0.tgz",
+      "integrity": "sha512-bZc6YOjRkMBVA16527tgzi6iN9n//xRB3Mmx/R+Gr6UAP/+xrIKOejQIcn1hh+tCzNT8jO0jI+kWox5J4tB/qQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "@firebase/webchannel-wrapper": "1.0.5",
+        "@grpc/grpc-js": "~1.9.0",
+        "@grpc/proto-loader": "^0.7.8",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-compat": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-compat/-/firestore-compat-0.4.8.tgz",
+      "integrity": "sha512-WK9NJRpnosGD2nuyjdr7K+Ht7AxRYJlTF62myI4rRA7ibJOosbecvjacR5oirJ7s1BgNS6qzcBw7n4fD3a5w1w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/firestore": "4.14.0",
+        "@firebase/firestore-types": "3.0.3",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/firestore-types": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@firebase/firestore-types/-/firestore-types-3.0.3.tgz",
+      "integrity": "sha512-hD2jGdiWRxB/eZWF89xcK9gF8wvENDJkzpVFb4aGkzfEaKxVRD1kjz1t1Wj8VZEp2LCB53Yx1zD8mrhQu87R6Q==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/functions": {
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.13.3.tgz",
+      "integrity": "sha512-csO7ckK3SSs+NUZW1nms9EK7ckHe/1QOjiP8uAkCYa7ND18s44vjE9g3KxEeIUpyEPqZaX1EhJuFyZjHigAcYw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/app-check-interop-types": "0.3.3",
+        "@firebase/auth-interop-types": "0.2.4",
+        "@firebase/component": "0.7.2",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-compat": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-compat/-/functions-compat-0.4.3.tgz",
+      "integrity": "sha512-BxkEwWgx1of0tKaao/r2VR6WBLk/RAiyztatiONPrPE8gkitFkOnOCxf8i9cUyA5hX5RGt5H30uNn25Q6QNEmQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/functions": "0.13.3",
+        "@firebase/functions-types": "0.6.3",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/functions-types": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@firebase/functions-types/-/functions-types-0.6.3.tgz",
+      "integrity": "sha512-EZoDKQLUHFKNx6VLipQwrSMh01A1SaL3Wg6Hpi//x6/fJ6Ee4hrAeswK99I5Ht8roiniKHw4iO0B1Oxj5I4plg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/installations": {
+      "version": "0.6.21",
+      "resolved": "https://registry.npmjs.org/@firebase/installations/-/installations-0.6.21.tgz",
+      "integrity": "sha512-xGFGTeICJZ5vhrmmDukeczIcFULFXybojML2+QSDFoKj5A7zbGN7KzFGSKNhDkIxpjzsYG9IleJyUebuAcmqWA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/util": "1.15.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-compat": {
+      "version": "0.2.21",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-compat/-/installations-compat-0.2.21.tgz",
+      "integrity": "sha512-zahIUkaVKbR8zmTeBHkdfaVl6JGWlhVoSjF7CVH33nFqD3SlPEpEEegn2GNT5iAfsVdtlCyJJ9GW4YKjq+RJKQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
+        "@firebase/installations-types": "0.5.3",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/installations-types": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/@firebase/installations-types/-/installations-types-0.5.3.tgz",
+      "integrity": "sha512-2FJI7gkLqIE0iYsNQ1P751lO3hER+Umykel+TkLwHj6plzWVxqvfclPUZhcKFVQObqloEBTmpi2Ozn7EkCABAA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x"
+      }
+    },
+    "node_modules/@firebase/logger": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/logger/-/logger-0.5.0.tgz",
+      "integrity": "sha512-cGskaAvkrnh42b3BA3doDWeBmuHFO/Mx5A83rbRDYakPjO9bJtRL3dX7javzc2Rr/JHZf4HlterTW2lUkfeN4g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/messaging": {
+      "version": "0.12.25",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.12.25.tgz",
+      "integrity": "sha512-7RhDwoDHlOK1/ou0/LeubxmjcngsTjDdrY/ssg2vwAVpUuVAhQzQvuCAOYxcX5wNC1zCgQ54AP1vdngBwbCmOQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
+        "@firebase/messaging-interop-types": "0.2.3",
+        "@firebase/util": "1.15.0",
+        "idb": "7.1.1",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-compat": {
+      "version": "0.2.25",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-compat/-/messaging-compat-0.2.25.tgz",
+      "integrity": "sha512-eoOQqGLtRlseTdiemTN44LlHZpltK5gnhq8XVUuLgtIOG+odtDzrz2UoTpcJWSzaJQVxNLb/x9f39tHdDM4N4w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/messaging": "0.12.25",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/messaging-interop-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/messaging-interop-types/-/messaging-interop-types-0.2.3.tgz",
+      "integrity": "sha512-xfzFaJpzcmtDjycpDeCUj0Ge10ATFi/VHVIvEEjDNc3hodVBQADZ7BWQU7CuFpjSHE+eLuBI13z5F/9xOoGX8Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/performance": {
+      "version": "0.7.11",
+      "resolved": "https://registry.npmjs.org/@firebase/performance/-/performance-0.7.11.tgz",
+      "integrity": "sha512-V3uAhrz7IYJuji+OgT3qYTGKxpek/TViXti9OSsUJ4AexZ3jQjYH5Yrn7JvBxk8MGiSLsC872hh+BxQiPZsm7g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0",
+        "web-vitals": "^4.2.4"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-compat": {
+      "version": "0.2.24",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-compat/-/performance-compat-0.2.24.tgz",
+      "integrity": "sha512-YRlejH8wLt7ThWao+HXoKUHUrZKGYq+otxkPS+8nuE5PeN1cBXX7NAJl9ueuUkBwMIrnKdnDqL/voHXxDAAt3g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/performance": "0.7.11",
+        "@firebase/performance-types": "0.2.3",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/performance-types": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@firebase/performance-types/-/performance-types-0.2.3.tgz",
+      "integrity": "sha512-IgkyTz6QZVPAq8GSkLYJvwSLr3LS9+V6vNPQr0x4YozZJiLF5jYixj0amDtATf1X0EtYHqoPO48a9ija8GocxQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/remote-config": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config/-/remote-config-0.8.2.tgz",
+      "integrity": "sha512-5EXqOThV4upjK9D38d/qOSVwOqRhemlaOFk9vCkMNNALeIlwr+4pLjtLNo4qoY8etQmU/1q4aIATE9N8PFqg0g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/installations": "0.6.21",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-compat": {
+      "version": "0.2.23",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-compat/-/remote-config-compat-0.2.23.tgz",
+      "integrity": "sha512-4+KqRRHEUUmKT6tFmnpWATOsaFfmSuBs1jXH8JzVtMLEYqq/WS9IDM92OdefFDSrAA2xGd0WN004z8mKeIIscw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/remote-config": "0.8.2",
+        "@firebase/remote-config-types": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/remote-config-types": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@firebase/remote-config-types/-/remote-config-types-0.5.0.tgz",
+      "integrity": "sha512-vI3bqLoF14L/GchtgayMiFpZJF+Ao3uR8WCde0XpYNkSokDpAKca2DxvcfeZv7lZUqkUwQPL2wD83d3vQ4vvrg==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@firebase/storage": {
+      "version": "0.14.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.14.2.tgz",
+      "integrity": "sha512-o/culaTeJ8GRpKXRJov21rux/n9dRaSOWLebyatFP2sqEdCxQPjVA1H9Z2fzYwQxMIU0JVmC7SPPmU11v7L6vQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-compat": {
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-compat/-/storage-compat-0.4.2.tgz",
+      "integrity": "sha512-R+aB38wxCH5zjIO/xu9KznI7fgiPuZAG98uVm1NcidHyyupGgIDLKigGmRGBZMnxibe/m2oxNKoZpfEbUX2aQQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/storage": "0.14.2",
+        "@firebase/storage-types": "0.8.3",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app-compat": "0.x"
+      }
+    },
+    "node_modules/@firebase/storage-types": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/@firebase/storage-types/-/storage-types-0.8.3.tgz",
+      "integrity": "sha512-+Muk7g9uwngTpd8xn9OdF/D48uiQ7I1Fae7ULsWPuKoCH3HU7bfFPhxtJYzyhjdniowhuDpQcfPmuNRAqZEfvg==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@firebase/app-types": "0.x",
+        "@firebase/util": "1.x"
+      }
+    },
+    "node_modules/@firebase/util": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/@firebase/util/-/util-1.15.0.tgz",
+      "integrity": "sha512-AmWf3cHAOMbrCPG4xdPKQaj5iHnyYfyLKZxwz+Xf55bqKbpAmcYifB4jQinT2W9XhDRHISOoPyBOariJpCG6FA==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@firebase/webchannel-wrapper": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@firebase/webchannel-wrapper/-/webchannel-wrapper-1.0.5.tgz",
+      "integrity": "sha512-+uGNN7rkfn41HLO0vekTFhTxk61eKa8mTpRGLO0QSqlQdKvIoGAvLp3ppdVIWbTGYJWM6Kp0iN+PjMIOcnVqTw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@grpc/grpc-js": {
+      "version": "1.9.15",
+      "resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.9.15.tgz",
+      "integrity": "sha512-nqE7Hc0AzI+euzUwDAy0aY5hCp10r734gMGRdU+qOPX0XSceI2ULrcXB5U2xSc5VkWwalCj4M7GzCAygZl2KoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@grpc/proto-loader": "^0.7.8",
+        "@types/node": ">=12.12.47"
+      },
+      "engines": {
+        "node": "^8.13.0 || >=10.10.0"
+      }
+    },
+    "node_modules/@grpc/proto-loader": {
+      "version": "0.7.15",
+      "resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.7.15.tgz",
+      "integrity": "sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "lodash.camelcase": "^4.3.0",
+        "long": "^5.0.0",
+        "protobufjs": "^7.2.5",
+        "yargs": "^17.7.2"
+      },
+      "bin": {
+        "proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -811,6 +1454,70 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
+      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.0.tgz",
+      "integrity": "sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1",
+        "@protobufjs/inquire": "^1.1.0"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/inquire": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
+      "integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -1276,6 +1983,15 @@
       "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "license": "MIT"
     },
+    "node_modules/@types/node": {
+      "version": "25.6.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.6.0.tgz",
+      "integrity": "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.19.0"
+      }
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.15",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
@@ -1340,6 +2056,30 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/any-promise": {
@@ -1618,6 +2358,20 @@
         "url": "https://polar.sh/cva"
       }
     },
+    "node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/clsx": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -1626,6 +2380,24 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "license": "MIT"
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -2265,6 +3037,12 @@
       "integrity": "sha512-f/ZeWvW/BCXbhGEf1Ujp29EASo/lk1FDnETgNKwJrsVvGZhUWCZyg3xLJjAsxfOmt8KjswHmI5EwCQcPMpOYhQ==",
       "license": "EPL-2.0"
     },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
     "node_modules/entities": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
@@ -2320,7 +3098,6 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
       "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6"
@@ -2394,6 +3171,18 @@
         "reusify": "^1.0.4"
       }
     },
+    "node_modules/faye-websocket": {
+      "version": "0.11.4",
+      "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.4.tgz",
+      "integrity": "sha512-CzbClwlXAuiRQAlUyfqPgvPoNKTckTPGfwZV4ZdAhVcP2lh9KUxJg2b5GkE7XbjKQ3YJnQ9z6D9ntLAlB+tP8g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "websocket-driver": ">=0.5.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -2405,6 +3194,66 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/firebase": {
+      "version": "12.12.1",
+      "resolved": "https://registry.npmjs.org/firebase/-/firebase-12.12.1.tgz",
+      "integrity": "sha512-ee7xA+bTJLfjB9BP/8FQr3EkxmpAAGc1lNc5QkWgTDpUw24HYXFPm7FEWRdLtGnygxIdYpFmepSc5VjkI6NHhw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/ai": "2.11.1",
+        "@firebase/analytics": "0.10.21",
+        "@firebase/analytics-compat": "0.2.27",
+        "@firebase/app": "0.14.11",
+        "@firebase/app-check": "0.11.2",
+        "@firebase/app-check-compat": "0.4.2",
+        "@firebase/app-compat": "0.5.11",
+        "@firebase/app-types": "0.9.4",
+        "@firebase/auth": "1.13.0",
+        "@firebase/auth-compat": "0.6.5",
+        "@firebase/data-connect": "0.6.0",
+        "@firebase/database": "1.1.2",
+        "@firebase/database-compat": "2.1.3",
+        "@firebase/firestore": "4.14.0",
+        "@firebase/firestore-compat": "0.4.8",
+        "@firebase/functions": "0.13.3",
+        "@firebase/functions-compat": "0.4.3",
+        "@firebase/installations": "0.6.21",
+        "@firebase/installations-compat": "0.2.21",
+        "@firebase/messaging": "0.12.25",
+        "@firebase/messaging-compat": "0.2.25",
+        "@firebase/performance": "0.7.11",
+        "@firebase/performance-compat": "0.2.24",
+        "@firebase/remote-config": "0.8.2",
+        "@firebase/remote-config-compat": "0.2.23",
+        "@firebase/storage": "0.14.2",
+        "@firebase/storage-compat": "0.4.2",
+        "@firebase/util": "1.15.0"
+      }
+    },
+    "node_modules/firebase/node_modules/@firebase/auth": {
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-1.13.0.tgz",
+      "integrity": "sha512-mKkSLNym3UbnnZ06dAmtqzp5EpPGCANGCZDJbkoR135aoUdKG6Aizwcnp29RzsQpwH0nmy5nay17Sfbsh9oY8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@firebase/component": "0.7.2",
+        "@firebase/logger": "0.5.0",
+        "@firebase/util": "1.15.0",
+        "tslib": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "@firebase/app": "0.x",
+        "@react-native-async-storage/async-storage": "^2.2.0 || ^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@react-native-async-storage/async-storage": {
+          "optional": true
+        }
       }
     },
     "node_modules/fraction.js": {
@@ -2454,6 +3303,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "license": "ISC",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
       }
     },
     "node_modules/glob-parent": {
@@ -2654,6 +3512,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/http-parser-js": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.10.tgz",
+      "integrity": "sha512-Pysuw9XpUq5dVc/2SMHpuTY01RFl8fttgcyunjL7eEMhGM3cI4eOmiCycJDVCo/7O7ClfQD3SaI6ftDzqOXYMA==",
+      "license": "MIT"
+    },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
@@ -2665,6 +3529,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
     },
     "node_modules/inline-style-parser": {
       "version": "0.2.7",
@@ -2752,6 +3622,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/is-glob": {
@@ -2911,6 +3790,18 @@
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.22.tgz",
       "integrity": "sha512-XEawp1t0gxSi9x01glktRZ5HDy0HXqrM0x5pXQM98EaI0NxO6jVM7omDOxsuEo5UIASAnm2bRp1Jt/e0a2XU8Q==",
       "license": "MIT"
+    },
+    "node_modules/lodash.camelcase": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
+      "integrity": "sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==",
+      "license": "MIT"
+    },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0"
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -9340,6 +10231,30 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/protobufjs": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.6.tgz",
+      "integrity": "sha512-M71sTMB146U3u0di3yup8iM+zv8yPRNQVr1KK4tyBitl3qFvEGucq/rGDRShD2rsJhtN02RJaJ7j5X5hmy8SJg==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/fetch": "^1.1.0",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/inquire": "^1.1.1",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/queue-microtask": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
@@ -10070,6 +10985,15 @@
         "@types/unist": "*"
       }
     },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/resolve": {
       "version": "1.22.11",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
@@ -10192,6 +11116,26 @@
         "node": ">=6"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
@@ -10237,6 +11181,20 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/stringify-entities": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
@@ -10249,6 +11207,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/style-to-js": {
@@ -10499,6 +11469,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -10512,6 +11488,12 @@
       "engines": {
         "node": ">=14.17"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.19.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.19.2.tgz",
+      "integrity": "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==",
+      "license": "MIT"
     },
     "node_modules/unified": {
       "version": "11.0.5",
@@ -10842,11 +11824,66 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/web-vitals": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/web-vitals/-/web-vitals-4.2.4.tgz",
+      "integrity": "sha512-r4DIlprAGwJ7YM11VZp4R884m0Vmgr6EAKe3P+kO0PPj3Unqyvv59rczf6UiGcb9Z8QxZVcqKNwv/g0WNdWwsw==",
+      "license": "Apache-2.0"
+    },
     "node_modules/web-worker": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/web-worker/-/web-worker-1.5.0.tgz",
       "integrity": "sha512-RiMReJrTAiA+mBjGONMnjVDP2u3p9R1vkcGz6gDIrOMT3oGuYwX2WRMYI9ipkphSuE5XKEhydbhNEJh4NY9mlw==",
       "license": "Apache-2.0"
+    },
+    "node_modules/websocket-driver": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
+      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-parser-js": ">=0.5.1",
+        "safe-buffer": ">=5.1.0",
+        "websocket-extensions": ">=0.1.1"
+      },
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/websocket-extensions": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.4.tgz",
+      "integrity": "sha512-OqedPIGOfsDlo31UNwYbCFMSaO9m9G/0faIHj5/dZFDMFqPTcx6UwqyOy3COEaEOg/9VsGIpdqn62W5KhoKSpg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/yallist": {
       "version": "3.1.1",
@@ -10854,6 +11891,33 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/zwitch": {
       "version": "2.0.4",

--- a/package.json
+++ b/package.json
@@ -12,16 +12,17 @@
     "preview:web": "vite preview --config web/vite.config.ts"
   },
   "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.0",
-    "tailwind-merge": "^2.2.0",
+    "firebase": "^12.12.1",
     "lucide-react": "^0.312.0",
+    "mermaid": "^10.7.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
     "react-markdown": "^9.0.1",
-    "remark-gfm": "^4.0.0",
     "rehype-raw": "^7.0.0",
-    "mermaid": "^10.7.0"
+    "remark-gfm": "^4.0.0",
+    "tailwind-merge": "^2.2.0"
   },
   "devDependencies": {
     "@types/chrome": "^0.0.260",

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -86,6 +86,16 @@ const translations = {
     storageOverLimit: "Storage limit exceeded!",
     storageUsage: "Storage usage",
     deleteOldMemos: "Consider deleting old memos to free up space.",
+
+    // Sync (PWA only)
+    sync: "Sync",
+    syncDisabled: "Cloud sync is not configured",
+    syncDisabledHint:
+      "Set VITE_FIREBASE_* in web/.env to enable Google sign-in.",
+    syncSignedOut: "Local-only mode",
+    syncSignedIn: "Synced to cloud",
+    signInWithGoogle: "Sign in with Google",
+    signOut: "Sign out",
   },
   ja: {
     // App
@@ -170,6 +180,16 @@ const translations = {
     storageOverLimit: "ストレージ容量が上限を超えました！",
     storageUsage: "使用量",
     deleteOldMemos: "古いメモを削除して容量を確保してください。",
+
+    // Sync (PWA only)
+    sync: "同期",
+    syncDisabled: "クラウド同期は未設定です",
+    syncDisabledHint:
+      "web/.env に VITE_FIREBASE_* を設定すると Google ログインが有効になります。",
+    syncSignedOut: "ローカルのみで動作中",
+    syncSignedIn: "クラウドに同期中",
+    signInWithGoogle: "Google でログイン",
+    signOut: "ログアウト",
   },
 }
 

--- a/web/.env.example
+++ b/web/.env.example
@@ -1,0 +1,12 @@
+# Firebase web config for Colason PWA cloud sync.
+# Copy this file to web/.env and fill in values from
+# Firebase Console -> yomi-note-app project -> Project settings -> Your apps -> Web app "colason".
+# All VITE_FIREBASE_* values are public by design (web SDK config), but treat them as project-bound.
+
+VITE_FIREBASE_API_KEY=
+VITE_FIREBASE_AUTH_DOMAIN=yomi-note-app.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=yomi-note-app
+VITE_FIREBASE_APP_ID=
+# Optional:
+VITE_FIREBASE_STORAGE_BUCKET=
+VITE_FIREBASE_MESSAGING_SENDER_ID=1038875178392

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -7,6 +7,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { I18nProvider, useI18n } from "@/lib/i18n"
 import { Button } from "@/components/ui/button"
 import { useNewMemoShortcut } from "./use-new-memo-shortcut"
+import { SyncSettings } from "./components/sync-settings"
 
 function AppContent() {
   const { t } = useI18n()
@@ -82,10 +83,15 @@ function AppContent() {
             </div>
 
             <div className="pt-4 border-t">
+              <h2 className="text-lg font-semibold mb-4">{t("sync")}</h2>
+              <SyncSettings />
+            </div>
+
+            <div className="pt-4 border-t">
               <h2 className="text-lg font-semibold mb-4">{t("about")}</h2>
               <div className="space-y-2 text-sm text-muted-foreground">
                 <p>Colason Web Window (PWA standalone).</p>
-                <p>Memos are stored locally in IndexedDB on this device.</p>
+                <p>Sign in with Google to sync memos across devices.</p>
               </div>
             </div>
           </div>

--- a/web/src/components/sync-settings.tsx
+++ b/web/src/components/sync-settings.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react"
+import { Cloud, CloudOff, LogIn, LogOut } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useI18n } from "@/lib/i18n"
+import { useAuth } from "../hooks/use-auth"
+import { signInWithGoogle, signOutUser } from "../lib/firebase"
+
+export function SyncSettings() {
+  const { t } = useI18n()
+  const { user, isReady, isConfigured } = useAuth()
+  const [busy, setBusy] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSignIn = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      await signInWithGoogle()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleSignOut = async () => {
+    setBusy(true)
+    setError(null)
+    try {
+      await signOutUser()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!isConfigured) {
+    return (
+      <div className="space-y-2 text-sm text-muted-foreground">
+        <div className="flex items-center gap-2">
+          <CloudOff className="h-4 w-4" />
+          <span className="font-medium">{t("syncDisabled")}</span>
+        </div>
+        <p className="text-xs">{t("syncDisabledHint")}</p>
+      </div>
+    )
+  }
+
+  if (!isReady) {
+    return (
+      <div className="text-sm text-muted-foreground">{t("loading")}</div>
+    )
+  }
+
+  if (!user) {
+    return (
+      <div className="space-y-3">
+        <div className="flex items-center gap-2 text-sm">
+          <CloudOff className="h-4 w-4 text-muted-foreground" />
+          <span className="text-muted-foreground">{t("syncSignedOut")}</span>
+        </div>
+        <Button size="sm" onClick={handleSignIn} disabled={busy}>
+          <LogIn className="h-3.5 w-3.5 mr-1.5" />
+          {t("signInWithGoogle")}
+        </Button>
+        {error && (
+          <p className="text-xs text-destructive">{error}</p>
+        )}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center gap-2 text-sm">
+        <Cloud className="h-4 w-4 text-green-600" />
+        <span className="font-medium">{t("syncSignedIn")}</span>
+      </div>
+      <div className="text-xs text-muted-foreground space-y-1">
+        <div>{user.email ?? user.uid}</div>
+        {user.displayName && <div>{user.displayName}</div>}
+      </div>
+      <Button size="sm" variant="outline" onClick={handleSignOut} disabled={busy}>
+        <LogOut className="h-3.5 w-3.5 mr-1.5" />
+        {t("signOut")}
+      </Button>
+      {error && (
+        <p className="text-xs text-destructive">{error}</p>
+      )}
+    </div>
+  )
+}

--- a/web/src/hooks/use-auth.ts
+++ b/web/src/hooks/use-auth.ts
@@ -1,0 +1,28 @@
+import { useEffect, useState } from "react"
+import { isFirebaseConfigured, onAuthChanged, type User } from "../lib/firebase"
+
+interface AuthState {
+  user: User | null
+  isReady: boolean
+  isConfigured: boolean
+}
+
+export function useAuth(): AuthState {
+  const configured = isFirebaseConfigured()
+  const [user, setUser] = useState<User | null>(null)
+  const [isReady, setIsReady] = useState(!configured)
+
+  useEffect(() => {
+    if (!configured) {
+      setIsReady(true)
+      return
+    }
+    const unsub = onAuthChanged((u) => {
+      setUser(u)
+      setIsReady(true)
+    })
+    return () => unsub()
+  }, [configured])
+
+  return { user, isReady, isConfigured: configured }
+}

--- a/web/src/hooks/use-chrome-storage.ts
+++ b/web/src/hooks/use-chrome-storage.ts
@@ -1,0 +1,222 @@
+import { useState, useEffect, useCallback, useRef } from "react"
+import { idbGet, idbSet, isIdbAvailable } from "@/lib/idb-store"
+import { useAuth } from "./use-auth"
+import {
+  subscribeMemos,
+  upsertMemo,
+  patchMemo,
+  removeMemo,
+} from "../lib/firestore-memos"
+import { runMigrationOnce } from "../lib/migration"
+
+export interface Memo {
+  id: string
+  title: string
+  content: string
+  createdAt: number
+  updatedAt: number
+}
+
+function calculateStorageSize(data: unknown): number {
+  return new Blob([JSON.stringify(data)]).size
+}
+
+function hasChromeStorage(): boolean {
+  return (
+    typeof chrome !== "undefined" &&
+    !!(chrome as unknown as { storage?: { sync?: unknown } }).storage &&
+    !!(chrome as unknown as { storage?: { sync?: unknown } }).storage?.sync
+  )
+}
+
+async function loadLocal<T>(key: string, fallback: T): Promise<T> {
+  if (isIdbAvailable()) {
+    try {
+      const stored = await idbGet<T>(key)
+      if (stored !== undefined) return stored
+    } catch (err) {
+      console.warn("idb load failed, falling back to localStorage", err)
+    }
+  }
+  const ls = localStorage.getItem(key)
+  if (ls) {
+    try {
+      return JSON.parse(ls) as T
+    } catch {
+      return ls as unknown as T
+    }
+  }
+  return fallback
+}
+
+async function saveLocal<T>(key: string, value: T): Promise<void> {
+  if (isIdbAvailable()) {
+    try {
+      await idbSet(key, value)
+      return
+    } catch (err) {
+      console.warn("idb set failed, falling back to localStorage", err)
+    }
+  }
+  try {
+    localStorage.setItem(key, JSON.stringify(value))
+  } catch {
+    // best effort
+  }
+}
+
+export function useChromeStorage<T>(key: string, defaultValue: T) {
+  const [value, setValue] = useState<T>(defaultValue)
+  const [isLoading, setIsLoading] = useState(true)
+
+  useEffect(() => {
+    let cancelled = false
+    void loadLocal<T>(key, defaultValue).then((stored) => {
+      if (cancelled) return
+      setValue(stored)
+      setIsLoading(false)
+    })
+    return () => {
+      cancelled = true
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [key])
+
+  const setStoredValue = useCallback(
+    (newValue: T | ((prev: T) => T)) => {
+      setValue((prev) => {
+        const next = newValue instanceof Function ? newValue(prev) : newValue
+        void saveLocal(key, next)
+        return next
+      })
+    },
+    [key],
+  )
+
+  return [value, setStoredValue, isLoading] as const
+}
+
+export function useMemos() {
+  const { user, isReady } = useAuth()
+  const [localMemos, setLocalMemos] = useState<Memo[]>([])
+  const [cloudMemos, setCloudMemos] = useState<Memo[] | null>(null)
+  const [isLocalLoaded, setIsLocalLoaded] = useState(false)
+  const [isCloudLoaded, setIsCloudLoaded] = useState(false)
+  const localMemosRef = useRef<Memo[]>([])
+
+  useEffect(() => {
+    let cancelled = false
+    void loadLocal<Memo[]>("memos", []).then((stored) => {
+      if (cancelled) return
+      setLocalMemos(stored)
+      localMemosRef.current = stored
+      setIsLocalLoaded(true)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    localMemosRef.current = localMemos
+  }, [localMemos])
+
+  useEffect(() => {
+    if (!user) {
+      setCloudMemos(null)
+      setIsCloudLoaded(false)
+      return
+    }
+    if (!isLocalLoaded) return
+    void runMigrationOnce(user.uid, localMemosRef.current)
+    const unsub = subscribeMemos(user.uid, (memos) => {
+      setCloudMemos(memos)
+      setIsCloudLoaded(true)
+    })
+    return () => {
+      unsub()
+    }
+  }, [user, isLocalLoaded])
+
+  const isCloud = user !== null && cloudMemos !== null
+  const memos = isCloud ? (cloudMemos as Memo[]) : localMemos
+  const isLoading = !isReady || (user ? !isCloudLoaded : !isLocalLoaded)
+
+  const addMemo = useCallback(
+    (title: string, content: string) => {
+      const newMemo: Memo = {
+        id: crypto.randomUUID(),
+        title: title || "Untitled",
+        content,
+        createdAt: Date.now(),
+        updatedAt: Date.now(),
+      }
+      if (user) {
+        void upsertMemo(user.uid, newMemo)
+      } else {
+        setLocalMemos((prev) => {
+          const next = [newMemo, ...prev]
+          void saveLocal("memos", next)
+          return next
+        })
+      }
+      return newMemo
+    },
+    [user],
+  )
+
+  const updateMemo = useCallback(
+    (id: string, updates: Partial<Pick<Memo, "title" | "content">>) => {
+      if (user) {
+        void patchMemo(user.uid, id, updates)
+      } else {
+        setLocalMemos((prev) => {
+          const next = prev.map((memo) =>
+            memo.id === id
+              ? { ...memo, ...updates, updatedAt: Date.now() }
+              : memo,
+          )
+          void saveLocal("memos", next)
+          return next
+        })
+      }
+    },
+    [user],
+  )
+
+  const deleteMemo = useCallback(
+    (id: string) => {
+      if (user) {
+        void removeMemo(user.uid, id)
+      } else {
+        setLocalMemos((prev) => {
+          const next = prev.filter((memo) => memo.id !== id)
+          void saveLocal("memos", next)
+          return next
+        })
+      }
+    },
+    [user],
+  )
+
+  const getStorageInfo = useCallback(() => {
+    const sizeInBytes = calculateStorageSize(memos)
+    const usingChrome = hasChromeStorage()
+    const maxSize = usingChrome ? 8192 : Number.POSITIVE_INFINITY
+    const usagePercent = usingChrome ? (sizeInBytes / maxSize) * 100 : 0
+    const isNearLimit = usingChrome && usagePercent > 80
+    const isOverLimit = usingChrome && sizeInBytes > maxSize
+    return {
+      sizeInBytes,
+      maxSize,
+      usagePercent: Math.min(usagePercent, 100),
+      isNearLimit,
+      isOverLimit,
+      remainingBytes: usingChrome
+        ? Math.max(0, maxSize - sizeInBytes)
+        : Number.POSITIVE_INFINITY,
+    }
+  }, [memos])
+
+  return { memos, addMemo, updateMemo, deleteMemo, isLoading, getStorageInfo }
+}

--- a/web/src/lib/firebase.ts
+++ b/web/src/lib/firebase.ts
@@ -1,0 +1,121 @@
+import { initializeApp, type FirebaseApp, type FirebaseOptions } from "firebase/app"
+import {
+  getAuth,
+  GoogleAuthProvider,
+  signInWithPopup,
+  signOut,
+  onAuthStateChanged,
+  type Auth,
+  type User,
+} from "firebase/auth"
+import {
+  initializeFirestore,
+  persistentLocalCache,
+  persistentMultipleTabManager,
+  type Firestore,
+} from "firebase/firestore"
+
+interface FirebaseEnv {
+  apiKey: string
+  authDomain: string
+  projectId: string
+  appId: string
+  storageBucket?: string
+  messagingSenderId?: string
+}
+
+function readEnv(): FirebaseEnv | null {
+  const env = import.meta.env as Record<string, string | undefined>
+  const apiKey = env.VITE_FIREBASE_API_KEY
+  const authDomain = env.VITE_FIREBASE_AUTH_DOMAIN
+  const projectId = env.VITE_FIREBASE_PROJECT_ID
+  const appId = env.VITE_FIREBASE_APP_ID
+  if (!apiKey || !authDomain || !projectId || !appId) return null
+  return {
+    apiKey,
+    authDomain,
+    projectId,
+    appId,
+    storageBucket: env.VITE_FIREBASE_STORAGE_BUCKET,
+    messagingSenderId: env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  }
+}
+
+let cachedApp: FirebaseApp | null = null
+let cachedAuth: Auth | null = null
+let cachedDb: Firestore | null = null
+let configMissingWarned = false
+
+function getApp(): FirebaseApp | null {
+  if (cachedApp) return cachedApp
+  const cfg = readEnv()
+  if (!cfg) {
+    if (!configMissingWarned) {
+      console.info(
+        "[colason] Firebase config missing — running in local-only mode. " +
+          "Set VITE_FIREBASE_* in web/.env to enable sync.",
+      )
+      configMissingWarned = true
+    }
+    return null
+  }
+  const options: FirebaseOptions = {
+    apiKey: cfg.apiKey,
+    authDomain: cfg.authDomain,
+    projectId: cfg.projectId,
+    appId: cfg.appId,
+    ...(cfg.storageBucket ? { storageBucket: cfg.storageBucket } : {}),
+    ...(cfg.messagingSenderId ? { messagingSenderId: cfg.messagingSenderId } : {}),
+  }
+  cachedApp = initializeApp(options)
+  return cachedApp
+}
+
+export function isFirebaseConfigured(): boolean {
+  return readEnv() !== null
+}
+
+export function getFirebaseAuth(): Auth | null {
+  if (cachedAuth) return cachedAuth
+  const app = getApp()
+  if (!app) return null
+  cachedAuth = getAuth(app)
+  return cachedAuth
+}
+
+export function getFirebaseDb(): Firestore | null {
+  if (cachedDb) return cachedDb
+  const app = getApp()
+  if (!app) return null
+  cachedDb = initializeFirestore(app, {
+    localCache: persistentLocalCache({
+      tabManager: persistentMultipleTabManager(),
+    }),
+  })
+  return cachedDb
+}
+
+export async function signInWithGoogle(): Promise<User | null> {
+  const auth = getFirebaseAuth()
+  if (!auth) return null
+  const provider = new GoogleAuthProvider()
+  const result = await signInWithPopup(auth, provider)
+  return result.user
+}
+
+export async function signOutUser(): Promise<void> {
+  const auth = getFirebaseAuth()
+  if (!auth) return
+  await signOut(auth)
+}
+
+export function onAuthChanged(cb: (user: User | null) => void): () => void {
+  const auth = getFirebaseAuth()
+  if (!auth) {
+    cb(null)
+    return () => {}
+  }
+  return onAuthStateChanged(auth, (user) => cb(user))
+}
+
+export type { User }

--- a/web/src/lib/firestore-memos.ts
+++ b/web/src/lib/firestore-memos.ts
@@ -1,0 +1,111 @@
+import {
+  collection,
+  doc,
+  setDoc,
+  deleteDoc,
+  onSnapshot,
+  query,
+  orderBy,
+  serverTimestamp,
+  Timestamp,
+  type DocumentData,
+} from "firebase/firestore"
+import { getFirebaseDb } from "./firebase"
+import type { Memo } from "@/hooks/use-chrome-storage"
+
+const ROOT = "colason_users"
+const SUB = "memos"
+
+function memosCol(uid: string) {
+  const db = getFirebaseDb()
+  if (!db) return null
+  return collection(db, ROOT, uid, SUB)
+}
+
+function memoDoc(uid: string, id: string) {
+  const db = getFirebaseDb()
+  if (!db) return null
+  return doc(db, ROOT, uid, SUB, id)
+}
+
+function toMillis(value: unknown, fallback: number): number {
+  if (value instanceof Timestamp) return value.toMillis()
+  if (typeof value === "number") return value
+  return fallback
+}
+
+function fromDoc(data: DocumentData, id: string): Memo {
+  const fallback = Date.now()
+  return {
+    id,
+    title: typeof data.title === "string" ? data.title : "",
+    content: typeof data.content === "string" ? data.content : "",
+    createdAt: toMillis(data.createdAt, fallback),
+    updatedAt: toMillis(data.updatedAt, fallback),
+  }
+}
+
+export function subscribeMemos(
+  uid: string,
+  cb: (memos: Memo[]) => void,
+): () => void {
+  const col = memosCol(uid)
+  if (!col) {
+    cb([])
+    return () => {}
+  }
+  const q = query(col, orderBy("updatedAt", "desc"))
+  return onSnapshot(
+    q,
+    (snap) => {
+      const memos = snap.docs.map((d) => fromDoc(d.data(), d.id))
+      cb(memos)
+    },
+    (err) => {
+      console.error("[colason] memo subscription error", err)
+    },
+  )
+}
+
+export async function upsertMemo(
+  uid: string,
+  memo: Pick<Memo, "id" | "title" | "content" | "createdAt"> & {
+    updatedAt?: number
+  },
+): Promise<void> {
+  const ref = memoDoc(uid, memo.id)
+  if (!ref) return
+  await setDoc(
+    ref,
+    {
+      title: memo.title,
+      content: memo.content,
+      createdAt: memo.createdAt,
+      updatedAt: serverTimestamp(),
+    },
+    { merge: true },
+  )
+}
+
+export async function patchMemo(
+  uid: string,
+  id: string,
+  updates: Partial<Pick<Memo, "title" | "content">>,
+): Promise<void> {
+  const ref = memoDoc(uid, id)
+  if (!ref) return
+  await setDoc(
+    ref,
+    {
+      ...updates,
+      updatedAt: serverTimestamp(),
+    },
+    { merge: true },
+  )
+}
+
+export async function removeMemo(uid: string, id: string): Promise<void> {
+  const ref = memoDoc(uid, id)
+  if (!ref) return
+  await deleteDoc(ref)
+}

--- a/web/src/lib/migration.ts
+++ b/web/src/lib/migration.ts
@@ -1,0 +1,36 @@
+import { doc, getDoc, setDoc, serverTimestamp } from "firebase/firestore"
+import { getFirebaseDb } from "./firebase"
+import { upsertMemo } from "./firestore-memos"
+import type { Memo } from "@/hooks/use-chrome-storage"
+
+const ROOT = "colason_users"
+
+let inFlight: Promise<void> | null = null
+
+export function runMigrationOnce(uid: string, localMemos: Memo[]): Promise<void> {
+  if (inFlight) return inFlight
+  inFlight = (async () => {
+    const db = getFirebaseDb()
+    if (!db) return
+    const userRef = doc(db, ROOT, uid)
+    const snap = await getDoc(userRef)
+    if (snap.exists() && snap.data()?.migrationCompletedAt) {
+      return
+    }
+    for (const memo of localMemos) {
+      await upsertMemo(uid, memo)
+    }
+    await setDoc(
+      userRef,
+      {
+        migrationCompletedAt: serverTimestamp(),
+        migratedCount: localMemos.length,
+      },
+      { merge: true },
+    )
+  })().catch((err) => {
+    console.error("[colason] migration failed", err)
+    inFlight = null
+  })
+  return inFlight
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -10,9 +10,16 @@ export default defineConfig({
   publicDir: resolve(root, "public"),
   plugins: [react()],
   resolve: {
-    alias: {
-      "@": resolve(repoRoot, "src"),
-    },
+    alias: [
+      {
+        find: /^@\/hooks\/use-chrome-storage$/,
+        replacement: resolve(root, "src/hooks/use-chrome-storage.ts"),
+      },
+      {
+        find: "@",
+        replacement: resolve(repoRoot, "src"),
+      },
+    ],
   },
   server: {
     port: 5174,


### PR DESCRIPTION
## Summary

Closes #6.

PWA build に Google Sign-in + Firestore 同期を追加。yomi-note-app GCP project に **相乗り** しつつ、collection 名前空間で **完全分離** している。Chrome 拡張 build は影響を受けない。

## 設計方針

| 項目 | 決定 |
|------|------|
| GCP project | `yomi-note-app` (number `1038875178392`) に相乗り、新 project は作らない |
| Collection | `colason_users/{uid}/memos/{memoId}` (yomi-note の `users` / `papers` / 他とは完全分離) |
| Auth | Firebase Auth Google Sign-in (popup) — yomi-note の NextAuth とは独立、Auth provider のみ共有 |
| Storage tier | not signed-in: IndexedDB only / signed-in: Firestore source of truth + persistent local cache |
| Migration | 初回 sign-in 時 IndexedDB → Firestore を once 反映 (`migrationCompletedAt` flag で idempotent) |
| Conflict | last-write-wins (`updatedAt` server timestamp) |
| Bundle 分離 | Vite alias で PWA build のみ `@/hooks/use-chrome-storage` を web 版に向け替え、Chrome 拡張 build に firebase は混入させない (検証済) |

## 受け入れ基準

- [x] Firebase SDK (modular v12) 追加
- [x] Google Sign-in / Sign-out UI (Settings tab → Sync セクション、ja/en localized)
- [x] Firestore subcollection への CRUD (`upsertMemo` / `patchMemo` / `removeMemo` / `subscribeMemos`)
- [x] IndexedDB → Firestore migration (idempotent)
- [x] offline 編集 → 復帰時自動 sync (`persistentLocalCache` + `persistentMultipleTabManager`)
- [x] 未 sign-in 時は local-only (`isFirebaseConfigured()` false 時も同様)
- [x] Chrome 拡張 build (`dist/`) は firebase 文字列ゼロ (grep 確認済)
- [x] `web/.env.example` (VITE_FIREBASE_*)
- [x] README に「Cloud sync (PWA only)」セクション + Setup 手順
- [x] `firestore.rules.colason` を repo root に配置 (yomi-note 側で merge する手順は README に明記)
- [x] `web/.env`, `web/.env.local` を `.gitignore`

## 動作確認 (要 Firebase Console 設定)

事前手順:
1. Firebase Console → `yomi-note-app` project → **Add app → Web** で `colason` を登録、config を取得
2. `cp web/.env.example web/.env` → `VITE_FIREBASE_API_KEY` / `VITE_FIREBASE_APP_ID` を埋める
3. **Authentication → Sign-in method → Google** を有効化、`localhost` を authorized domains に追加
4. `firestore.rules.colason` を yomi-note repo の `firestore.rules` に append → re-deploy

ローカル確認:
```bash
npm install
npm run build:web && npm run preview:web
```
Settings タブで「Google でログイン」→ Firestore Console (`colason_users/{uid}/memos`) に doc が作成されることを確認。

ビルド確認:
- `npm run build:web` ✅ (typecheck pass, vite build success)
- `npm run build` ✅ (Chrome 拡張、firebase 不混入を grep で確認)

## Non-goals

- WebDAV / Dropbox 連携 (#6 で除外)
- リアルタイム collaborative 編集 (1 user 同時前提)
- Chrome 拡張版の Firestore 連携 (Phase 3、別 Issue)
- yomi-note 側への Web App 登録と rules merge (運用上の手作業、別途対応)

## 既存影響

- Chrome 拡張 build: ゼロ (`src/hooks/use-chrome-storage.ts` 未変更、bundle に firebase 不混入)
- yomi-note の `users` / `papers` / `terms` / `questions` / `reflections` / `feedbacks` / `drafts` collection: 完全分離 (`colason_users/` root)
- Sync 用 i18n key を `src/lib/i18n.tsx` に追加 (拡張側で参照されないため UI 影響なし)

🤖 Generated with [Claude Code](https://claude.com/claude-code)