### PR TITLE
feat(ext): standalone window mode (LINE for PC 風) — v1.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ web-dist
 .DS_Store
 web/.env
 web/.env.local
+# Chrome 拡張のパッケージ化成果物 (秘密鍵 + crx は絶対 commit しない)
+*.pem
+*.crx

--- a/manifest.json
+++ b/manifest.json
@@ -1,11 +1,15 @@
 {
   "name": "Colason",
-  "description": "A rich memo app with Markdown and Mermaid diagram support",
-  "version": "1.4",
+  "description": "A rich memo app with Markdown and Mermaid diagram support. Opens in a standalone window like LINE for PC.",
+  "version": "1.5",
   "manifest_version": 3,
   "permissions": ["storage"],
+  "background": {
+    "service_worker": "assets/background.js",
+    "type": "module"
+  },
   "action": {
-    "default_popup": "popup.html",
+    "default_title": "Open Colason",
     "default_icon": {
       "16": "images/get_started16.png",
       "32": "images/get_started32.png",

--- a/src/background.ts
+++ b/src/background.ts
@@ -1,0 +1,86 @@
+// Colason extension service worker.
+//
+// Replaces the old popup-on-toolbar-click flow with a standalone OS window
+// (LINE for PC style). Reusing popup.html so the React shell, theme, and
+// keyboard shortcuts stay identical.
+
+const POPUP_PAGE = "popup.html"
+const WINDOW_WIDTH = 480
+const WINDOW_HEIGHT = 720
+const STATE_KEY = "colason:windowState"
+
+interface PersistedWindowState {
+  windowId: number | null
+  left?: number
+  top?: number
+  width?: number
+  height?: number
+}
+
+async function readState(): Promise<PersistedWindowState> {
+  const stored = await chrome.storage.local.get(STATE_KEY)
+  const value = stored[STATE_KEY] as PersistedWindowState | undefined
+  return value ?? { windowId: null }
+}
+
+async function writeState(state: PersistedWindowState): Promise<void> {
+  await chrome.storage.local.set({ [STATE_KEY]: state })
+}
+
+async function openOrFocus(): Promise<void> {
+  const state = await readState()
+
+  if (state.windowId !== null) {
+    try {
+      await chrome.windows.update(state.windowId, {
+        focused: true,
+        drawAttention: true,
+      })
+      return
+    } catch {
+      // Window was closed since last write — fall through and create a new one.
+    }
+  }
+
+  const created = await chrome.windows.create({
+    url: chrome.runtime.getURL(POPUP_PAGE),
+    type: "popup",
+    width: state.width ?? WINDOW_WIDTH,
+    height: state.height ?? WINDOW_HEIGHT,
+    ...(state.left !== undefined ? { left: state.left } : {}),
+    ...(state.top !== undefined ? { top: state.top } : {}),
+  })
+
+  if (created?.id !== undefined) {
+    await writeState({
+      windowId: created.id,
+      left: created.left,
+      top: created.top,
+      width: created.width,
+      height: created.height,
+    })
+  }
+}
+
+chrome.action.onClicked.addListener(() => {
+  void openOrFocus()
+})
+
+chrome.windows.onRemoved.addListener(async (id) => {
+  const state = await readState()
+  if (state.windowId === id) {
+    await writeState({ ...state, windowId: null })
+  }
+})
+
+chrome.windows.onBoundsChanged?.addListener(async (window) => {
+  const state = await readState()
+  if (state.windowId !== window.id) return
+  await writeState({
+    windowId: window.id,
+    left: window.left,
+    top: window.top,
+    width: window.width,
+    height: window.height,
+  })
+})

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -49,6 +49,7 @@ export default defineConfig({
       input: {
         popup: resolve(__dirname, 'popup.html'),
         options: resolve(__dirname, 'options.html'),
+        background: resolve(__dirname, 'src/background.ts'),
       },
       output: {
         entryFileNames: 'assets/[name].js',


### PR DESCRIPTION
## Summary

Chrome 拡張版を **popup** タイプから **standalone window** タイプに切り替え。アイコンクリックで LINE for PC のような独立 OS ウィンドウが起動するようになります。

## Why

PR #8 で PWA 版に web window を入れましたが、CEO の元々の要求は **Chrome 拡張アイコンクリック → 独立ウィンドウ** という LINE 拡張機能と同じ挙動。dist/ を読み込んでも window 化されない (popup のまま) のはここが原因でした。

LINE 拡張も `chrome-extension://[id]/index.html#popout` で extension page を独立ウィンドウとして開く方式 (= MV3 で `chrome.windows.create({ type: "popup" })`) と推測される (Chrome Apps API は 2022 年に廃止)。本 PR はこの方式を採用。

## 実装

- `src/background.ts` (新規 service worker):
  - `chrome.action.onClicked` を listen → `chrome.windows.create({ url: chrome.runtime.getURL("popup.html"), type: "popup", width: 480, height: 720 })`
  - `chrome.storage.local` にウィンドウ位置/サイズを persist、再起動時に復元
  - 既に開いていれば `chrome.windows.update({ focused: true, drawAttention: true })` でシングルトン化
  - `chrome.windows.onRemoved` / `onBoundsChanged` で state 同期
- `manifest.json`:
  - `action.default_popup` を削除 (popup モードを stop)
  - `background.service_worker: "assets/background.js"` + `type: "module"` (MV3 ES module)
  - `version` 1.4 → 1.5
- `vite.config.ts`: rollup input に `background: src/background.ts` を追加
- `.gitignore`: `*.pem` / `*.crx` 追加 (extension 秘密鍵漏洩防止)

## 動作確認

```bash
npm run build         # → dist/ に manifest.json + assets/background.js + popup.html
```

`chrome://extensions/` → デベロッパーモード → 「パッケージ化されていない拡張機能を読み込む」→ `dist/` を選択。
ツールバーの Colason アイコンをクリック → **独立 OS ウィンドウで Colason が起動**。Chrome を閉じてもウィンドウは残る。再度クリックすると既存ウィンドウが focus される。

## Non-goals

- PWA 版 (`web-dist/`) は変更なし — 引き続き「アプリとしてインストール」で取り込み可能
- Chrome ウェブストア向けの提出パッケージ作成は別タスク (現状 zip 化スクリプトなし、`cd dist && zip ...` で手動)

## 既存影響

- v1.4 → v1.5 の差分は **background SW 追加のみ**。popup.html / 既存メモは無変更で互換
- 同期機能 (Firestore、PR #12) は **PWA 専用** で、拡張版には依然として載らない (拡張は `chrome.storage.sync` のまま)

🤖 Generated with [Claude Code](https://claude.com/claude-code)