### PR TITLE
feat(ext): window size preset (S/M/L) + ライブ resize — v1.6

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "Colason",
   "description": "A rich memo app with Markdown and Mermaid diagram support. Opens in a standalone window like LINE for PC.",
-  "version": "1.5",
+  "version": "1.6",
   "manifest_version": 3,
   "permissions": ["storage"],
   "background": {

--- a/src/background.ts
+++ b/src/background.ts
@@ -84,3 +84,54 @@ chrome.windows.onBoundsChanged?.addListener(async (window) => {
     height: window.height,
   })
 })
+
+interface ResizeMessage {
+  type: "resize"
+  width?: number
+  height?: number
+}
+
+interface ResizeResponse {
+  ok: boolean
+  reason?: string
+}
+
+function isResizeMessage(value: unknown): value is ResizeMessage {
+  if (typeof value !== "object" || value === null) return false
+  const candidate = value as Record<string, unknown>
+  return candidate.type === "resize"
+}
+
+async function applyResize(width?: number, height?: number): Promise<ResizeResponse> {
+  const state = await readState()
+
+  if (state.windowId === null) {
+    await writeState({
+      ...state,
+      ...(width !== undefined ? { width } : {}),
+      ...(height !== undefined ? { height } : {}),
+    })
+    return { ok: true, reason: "persisted-only" }
+  }
+
+  try {
+    await chrome.windows.update(state.windowId, {
+      ...(width !== undefined ? { width } : {}),
+      ...(height !== undefined ? { height } : {}),
+    })
+    await writeState({
+      ...state,
+      ...(width !== undefined ? { width } : {}),
+      ...(height !== undefined ? { height } : {}),
+    })
+    return { ok: true }
+  } catch (err) {
+    return { ok: false, reason: err instanceof Error ? err.message : "unknown" }
+  }
+}
+
+chrome.runtime.onMessage.addListener((message, _sender, sendResponse) => {
+  if (!isResizeMessage(message)) return false
+  void applyResize(message.width, message.height).then(sendResponse)
+  return true
+})

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -4,11 +4,24 @@ type Theme = "dark" | "light" | "system"
 type AccentColor = "default" | "blue" | "green" | "purple" | "orange" | "rose"
 type SizeOption = "small" | "medium" | "large"
 
+const WIDTH_PX: Record<SizeOption, number> = {
+  small: 450,
+  medium: 600,
+  large: 800,
+}
+
+const HEIGHT_PX: Record<SizeOption, number> = {
+  small: 600,
+  medium: 760,
+  large: 960,
+}
+
 type ThemeProviderProps = {
   children: React.ReactNode
   defaultTheme?: Theme
   defaultAccent?: AccentColor
   defaultWidth?: SizeOption
+  defaultHeight?: SizeOption
   storageKey?: string
 }
 
@@ -16,18 +29,22 @@ type ThemeProviderState = {
   theme: Theme
   accent: AccentColor
   width: SizeOption
+  height: SizeOption
   setTheme: (theme: Theme) => void
   setAccent: (accent: AccentColor) => void
   setWidth: (width: SizeOption) => void
+  setHeight: (height: SizeOption) => void
 }
 
 const initialState: ThemeProviderState = {
   theme: "system",
   accent: "default",
   width: "medium",
+  height: "medium",
   setTheme: () => null,
   setAccent: () => null,
   setWidth: () => null,
+  setHeight: () => null,
 }
 
 const ThemeProviderContext = createContext<ThemeProviderState>(initialState)
@@ -46,18 +63,20 @@ export function ThemeProvider({
   defaultTheme = "system",
   defaultAccent = "default",
   defaultWidth = "medium",
+  defaultHeight = "medium",
   storageKey = "memo-theme",
 }: ThemeProviderProps) {
   const [theme, setTheme] = useState<Theme>(defaultTheme)
   const [accent, setAccent] = useState<AccentColor>(defaultAccent)
   const [width, setWidth] = useState<SizeOption>(defaultWidth)
+  const [height, setHeight] = useState<SizeOption>(defaultHeight)
   const [isLoaded, setIsLoaded] = useState(false)
 
   useEffect(() => {
     // Load settings from Chrome storage
     if (typeof chrome !== "undefined" && chrome.storage) {
       chrome.storage.sync.get(
-        [storageKey, `${storageKey}-accent`, `${storageKey}-width`],
+        [storageKey, `${storageKey}-accent`, `${storageKey}-width`, `${storageKey}-height`],
         (result) => {
           if (result[storageKey]) {
             setTheme(result[storageKey] as Theme)
@@ -68,6 +87,9 @@ export function ThemeProvider({
           if (result[`${storageKey}-width`]) {
             setWidth(result[`${storageKey}-width`] as SizeOption)
           }
+          if (result[`${storageKey}-height`]) {
+            setHeight(result[`${storageKey}-height`] as SizeOption)
+          }
           setIsLoaded(true)
         }
       )
@@ -76,9 +98,11 @@ export function ThemeProvider({
       const storedTheme = localStorage.getItem(storageKey) as Theme
       const storedAccent = localStorage.getItem(`${storageKey}-accent`) as AccentColor
       const storedWidth = localStorage.getItem(`${storageKey}-width`) as SizeOption
+      const storedHeight = localStorage.getItem(`${storageKey}-height`) as SizeOption
       if (storedTheme) setTheme(storedTheme)
       if (storedAccent) setAccent(storedAccent)
       if (storedWidth) setWidth(storedWidth)
+      if (storedHeight) setHeight(storedHeight)
       setIsLoaded(true)
     }
   }, [storageKey])
@@ -104,7 +128,7 @@ export function ThemeProvider({
     root.style.setProperty("--primary", colors.primary)
     root.style.setProperty("--primary-foreground", colors.primaryForeground)
 
-    // Width
+    // Width (CSS class for in-popup layout)
     root.classList.remove("width-small", "width-medium", "width-large")
     root.classList.add(`width-${width}`)
 
@@ -114,21 +138,39 @@ export function ThemeProvider({
         [storageKey]: theme,
         [`${storageKey}-accent`]: accent,
         [`${storageKey}-width`]: width,
+        [`${storageKey}-height`]: height,
       })
     } else {
       localStorage.setItem(storageKey, theme)
       localStorage.setItem(`${storageKey}-accent`, accent)
       localStorage.setItem(`${storageKey}-width`, width)
+      localStorage.setItem(`${storageKey}-height`, height)
     }
-  }, [theme, accent, width, isLoaded, storageKey])
+
+    // Resize the standalone OS window (PR #13 mode). chrome.runtime.sendMessage
+    // is only available in extension context — silently skip for the PWA build.
+    if (typeof chrome !== "undefined" && chrome.runtime?.sendMessage) {
+      try {
+        chrome.runtime.sendMessage({
+          type: "resize",
+          width: WIDTH_PX[width],
+          height: HEIGHT_PX[height],
+        })
+      } catch {
+        // Service worker may be asleep; resize will apply on next open.
+      }
+    }
+  }, [theme, accent, width, height, isLoaded, storageKey])
 
   const value = {
     theme,
     accent,
     width,
+    height,
     setTheme,
     setAccent,
     setWidth,
+    setHeight,
   }
 
   return (

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,4 +1,4 @@
-import { Moon, Sun, Monitor, Palette, MoveHorizontal } from "lucide-react"
+import { Moon, Sun, Monitor, Palette, MoveHorizontal, MoveVertical } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { useTheme, type Theme, type AccentColor, type SizeOption } from "@/components/theme-provider"
 import {
@@ -11,7 +11,7 @@ import {
 import { useI18n } from "@/lib/i18n"
 
 export function ThemeToggle() {
-  const { theme, setTheme, accent, setAccent, width, setWidth } = useTheme()
+  const { theme, setTheme, accent, setAccent, width, setWidth, height, setHeight } = useTheme()
   const { t } = useI18n()
 
   const themes: { value: Theme; labelKey: "light" | "dark" | "system"; icon: React.ReactNode }[] = [
@@ -33,6 +33,12 @@ export function ThemeToggle() {
     { value: "small", label: "S", size: "450px" },
     { value: "medium", label: "M", size: "600px" },
     { value: "large", label: "L", size: "800px" },
+  ]
+
+  const heightOptions: { value: SizeOption; label: string; size: string }[] = [
+    { value: "small", label: "S", size: "600px" },
+    { value: "medium", label: "M", size: "760px" },
+    { value: "large", label: "L", size: "960px" },
   ]
 
   return (
@@ -83,7 +89,7 @@ export function ThemeToggle() {
       <div className="space-y-2">
         <label className="text-sm font-medium flex items-center gap-2">
           <MoveHorizontal className="h-4 w-4" />
-          {t("popupWidth")}
+          {t("windowWidth")}
         </label>
         <div className="flex gap-1">
           {widthOptions.map((opt) => (
@@ -99,8 +105,29 @@ export function ThemeToggle() {
             </Button>
           ))}
         </div>
+      </div>
+
+      <div className="space-y-2">
+        <label className="text-sm font-medium flex items-center gap-2">
+          <MoveVertical className="h-4 w-4" />
+          {t("windowHeight")}
+        </label>
+        <div className="flex gap-1">
+          {heightOptions.map((opt) => (
+            <Button
+              key={opt.value}
+              variant={height === opt.value ? "default" : "outline"}
+              size="sm"
+              onClick={() => setHeight(opt.value)}
+              className="flex-1 flex flex-col items-center gap-0 h-auto py-1.5"
+            >
+              <span className="font-medium text-xs">{opt.label}</span>
+              <span className="text-[10px] opacity-70">{opt.size}</span>
+            </Button>
+          ))}
+        </div>
         <p className="text-xs text-muted-foreground">
-          {t("reopenToApply")}
+          {t("dragToResize")}
         </p>
       </div>
     </div>

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -54,6 +54,9 @@ const translations = {
     accentColor: "Accent Color",
     popupWidth: "Popup Width",
     reopenToApply: "Reopen the popup to apply width changes",
+    windowWidth: "Window Width",
+    windowHeight: "Window Height",
+    dragToResize: "You can also drag the window edges to resize freely.",
 
     // Colors
     default: "Default",
@@ -148,6 +151,9 @@ const translations = {
     accentColor: "アクセントカラー",
     popupWidth: "ポップアップの横幅",
     reopenToApply: "横幅変更はポップアップを開き直すと適用されます",
+    windowWidth: "ウィンドウ幅",
+    windowHeight: "ウィンドウ高さ",
+    dragToResize: "ウィンドウの端をドラッグして自由にサイズ変更もできます。",
 
     // Colors
     default: "デフォルト",


### PR DESCRIPTION
## Summary

Settings → Appearance に **ウィンドウ幅 / 高さプリセット (S/M/L)** を追加。プリセット切り替えで OS ウィンドウが即座にリサイズされ、サイズは \`chrome.storage.sync\` に persist。OS の端ドラッグも従来どおり \`onBoundsChanged\` で persist 継続。

PR #13 で popup → standalone window 化したことで旧 \`popupWidth\` (CSS class で内部 layout だけ変える) は無意味になっていたため、本 PR でウィンドウサイズ自体の制御に置き換えた。

## 変更点

| ファイル | 内容 |
|---|---|
| \`src/background.ts\` | \`chrome.runtime.onMessage\` に \`{type:"resize", width, height}\` ハンドラ追加。\`chrome.windows.update\` で実ウィンドウをリサイズし、windowState を更新 |
| \`src/components/theme-provider.tsx\` | \`height: SizeOption\` を追加、\`WIDTH_PX\` / \`HEIGHT_PX\` 定数で px 値を集約、useEffect で resize メッセージを送出 |
| \`src/components/theme-toggle.tsx\` | "Window Width" / "Window Height" の 2 行プリセット (S/M/L)、旧 popupWidth UI 廃止 |
| \`src/lib/i18n.tsx\` | \`windowWidth\` / \`windowHeight\` / \`dragToResize\` を ja/en 追加 |
| \`manifest.json\` | 1.5 → 1.6 |

## サイズプリセット

| | Width | Height |
|---|-------|--------|
| S | 450px | 600px |
| M (default) | 600px | 760px |
| L | 800px | 960px |

## Test plan

- [ ] \`npm run build\` 成功 (本 PR で確認済)
- [ ] \`chrome://extensions/\` で「更新」 → アイコンクリック → ウィンドウ起動
- [ ] Settings → Appearance → 幅/高さの S/M/L をクリック → 即座にリサイズ
- [ ] ウィンドウ右下角を OS でドラッグ → 自由サイズに変更
- [ ] ウィンドウを閉じて再度クリック → 直前のサイズで復元
- [ ] 別 PC で同 Google アカウントの拡張を起動 → 幅/高さプリセットが同期されている (chrome.storage.sync 経由)

🤖 Generated with [Claude Code](https://claude.com/claude-code)