### PR TITLE
feat(ext): Firestore sync with chrome.identity (auto sign-in)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,15 @@
+# Firebase web config for Colason Chrome extension cloud sync.
+# Copy this file to .env (root) and fill in values from Firebase Console
+# (yomi-note-app project -> Project settings -> Your apps -> Web app "colason").
+# Same values as web/.env — this file feeds the extension build.
+#
+# These values are public by design (web SDK config). Restrict by Firestore
+# Security Rules + the OAuth client_id in manifest.json.
+
+VITE_FIREBASE_API_KEY=
+VITE_FIREBASE_AUTH_DOMAIN=yomi-note-app.firebaseapp.com
+VITE_FIREBASE_PROJECT_ID=yomi-note-app
+VITE_FIREBASE_APP_ID=
+# Optional:
+VITE_FIREBASE_STORAGE_BUCKET=
+VITE_FIREBASE_MESSAGING_SENDER_ID=1038875178392

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ web-dist
 .DS_Store
 web/.env
 web/.env.local
+.env
+.env.local
 # Chrome 拡張のパッケージ化成果物 (秘密鍵 + crx は絶対 commit しない)
 *.pem
 *.crx

--- a/manifest.json
+++ b/manifest.json
@@ -30,7 +30,7 @@
     "128": "images/get_started128.png"
   },
   "oauth2": {
-    "client_id": "REPLACE_ME.apps.googleusercontent.com",
+    "client_id": "1038875178392-gk4986sids2099jdgpao6i3rlhjh4brk.apps.googleusercontent.com",
     "scopes": [
       "openid",
       "email",

--- a/manifest.json
+++ b/manifest.json
@@ -3,7 +3,13 @@
   "description": "A rich memo app with Markdown and Mermaid diagram support. Opens in a standalone window like LINE for PC.",
   "version": "1.5",
   "manifest_version": 3,
-  "permissions": ["storage"],
+  "permissions": ["storage", "identity"],
+  "host_permissions": [
+    "https://*.googleapis.com/*",
+    "https://*.firebaseio.com/*",
+    "https://securetoken.googleapis.com/*",
+    "https://identitytoolkit.googleapis.com/*"
+  ],
   "background": {
     "service_worker": "assets/background.js",
     "type": "module"
@@ -22,6 +28,14 @@
     "32": "images/get_started32.png",
     "48": "images/get_started48.png",
     "128": "images/get_started128.png"
+  },
+  "oauth2": {
+    "client_id": "REPLACE_ME.apps.googleusercontent.com",
+    "scopes": [
+      "openid",
+      "email",
+      "profile"
+    ]
   },
   "options_page": "options.html"
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { Settings } from "lucide-react"
 import { ThemeProvider } from "@/components/theme-provider"
 import { ThemeToggle } from "@/components/theme-toggle"
 import { MemoList } from "@/components/memo-list"
+import { SyncControl } from "@/components/sync-control"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { I18nProvider, useI18n } from "@/lib/i18n"
 
@@ -35,6 +36,11 @@ function AppContent() {
             <div>
               <h2 className="text-lg font-semibold mb-4">{t("appearance")}</h2>
               <ThemeToggle />
+            </div>
+
+            <div className="pt-4 border-t">
+              <h2 className="text-lg font-semibold mb-4">{t("sync")}</h2>
+              <SyncControl />
             </div>
 
             <div className="pt-4 border-t">

--- a/src/components/sync-control.tsx
+++ b/src/components/sync-control.tsx
@@ -1,0 +1,108 @@
+import { useState } from "react"
+import { CloudOff, Cloud, LogIn, LogOut, Loader2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import { useAuth } from "@/hooks/use-auth"
+import {
+  signInWithChromeIdentity,
+  signOutUser,
+} from "@/lib/firebase"
+import { useI18n } from "@/lib/i18n"
+
+export function SyncControl() {
+  const { user, isReady, isConfigured } = useAuth()
+  const { t } = useI18n()
+  const [busy, setBusy] = useState(false)
+
+  const handleSignIn = async () => {
+    setBusy(true)
+    try {
+      await signInWithChromeIdentity()
+    } catch (err) {
+      console.error("[colason] sign-in failed", err)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  const handleSignOut = async () => {
+    setBusy(true)
+    try {
+      await signOutUser()
+    } catch (err) {
+      console.error("[colason] sign-out failed", err)
+    } finally {
+      setBusy(false)
+    }
+  }
+
+  if (!isConfigured) {
+    return (
+      <div className="space-y-2">
+        <label className="text-sm font-medium flex items-center gap-2">
+          <CloudOff className="h-4 w-4" />
+          {t("sync")}
+        </label>
+        <p className="text-xs text-muted-foreground">{t("syncDisabled")}</p>
+        <p className="text-xs text-muted-foreground">{t("syncDisabledHint")}</p>
+      </div>
+    )
+  }
+
+  if (!isReady) {
+    return (
+      <div className="space-y-2">
+        <label className="text-sm font-medium flex items-center gap-2">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          {t("sync")}
+        </label>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-2">
+      <label className="text-sm font-medium flex items-center gap-2">
+        {user ? (
+          <Cloud className="h-4 w-4 text-green-600" />
+        ) : (
+          <CloudOff className="h-4 w-4 text-muted-foreground" />
+        )}
+        {t("sync")}
+      </label>
+      {user ? (
+        <div className="flex items-center justify-between gap-2">
+          <div className="text-xs text-muted-foreground truncate flex-1">
+            {t("syncSignedIn")} — {user.email ?? user.uid}
+          </div>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleSignOut}
+            disabled={busy}
+            className="flex items-center gap-2"
+          >
+            <LogOut className="h-3.5 w-3.5" />
+            {t("signOut")}
+          </Button>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          <p className="text-xs text-muted-foreground">{t("syncSignedOut")}</p>
+          <Button
+            size="sm"
+            onClick={handleSignIn}
+            disabled={busy}
+            className="flex items-center gap-2 w-full"
+          >
+            {busy ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <LogIn className="h-3.5 w-3.5" />
+            )}
+            {t("signInWithGoogle")}
+          </Button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -1,0 +1,39 @@
+import { useEffect, useState } from "react"
+import {
+  isFirebaseConfigured,
+  onAuthChanged,
+  silentSignInWithChromeIdentity,
+  type User,
+} from "@/lib/firebase"
+
+interface AuthState {
+  user: User | null
+  isReady: boolean
+  isConfigured: boolean
+}
+
+export function useAuth(): AuthState {
+  const configured = isFirebaseConfigured()
+  const [user, setUser] = useState<User | null>(null)
+  const [isReady, setIsReady] = useState(!configured)
+
+  useEffect(() => {
+    if (!configured) {
+      setIsReady(true)
+      return
+    }
+    const unsub = onAuthChanged((u) => {
+      setUser(u)
+      setIsReady(true)
+      // If we don't have a user yet, attempt a non-interactive sign-in
+      // using the cached chrome.identity token. This is what makes the
+      // experience "auto sign-in" for users already consented before.
+      if (u === null) {
+        void silentSignInWithChromeIdentity()
+      }
+    })
+    return () => unsub()
+  }, [configured])
+
+  return { user, isReady, isConfigured: configured }
+}

--- a/src/hooks/use-chrome-storage.ts
+++ b/src/hooks/use-chrome-storage.ts
@@ -1,7 +1,15 @@
 import { useState, useEffect, useCallback, useRef } from "react"
 import { idbGet, idbSet, isIdbAvailable } from "@/lib/idb-store"
+import {
+  subscribeMemos,
+  upsertMemo,
+  patchMemo,
+  removeMemo,
+} from "@/lib/firestore-memos"
+import { runMigrationOnce } from "@/lib/migration"
+import { useAuth } from "./use-auth"
 
-function calculateStorageSize(data: any): number {
+function calculateStorageSize(data: unknown): number {
   return new Blob([JSON.stringify(data)]).size
 }
 
@@ -112,8 +120,100 @@ export interface Memo {
   updatedAt: number
 }
 
+function loadLocalMemos(): Promise<Memo[]> {
+  return new Promise((resolve) => {
+    if (hasChromeStorage()) {
+      chrome.storage.sync.get(["memos"], (result) => {
+        const value = result["memos"]
+        resolve(Array.isArray(value) ? (value as Memo[]) : [])
+      })
+      return
+    }
+    if (isIdbAvailable()) {
+      idbGet<Memo[]>("memos")
+        .then((stored) => resolve(Array.isArray(stored) ? stored : []))
+        .catch(() => {
+          const ls = localStorage.getItem("memos")
+          try {
+            resolve(ls ? (JSON.parse(ls) as Memo[]) : [])
+          } catch {
+            resolve([])
+          }
+        })
+      return
+    }
+    const ls = localStorage.getItem("memos")
+    try {
+      resolve(ls ? (JSON.parse(ls) as Memo[]) : [])
+    } catch {
+      resolve([])
+    }
+  })
+}
+
+function saveLocalMemos(memos: Memo[]): void {
+  if (hasChromeStorage()) {
+    chrome.storage.sync.set({ memos })
+    return
+  }
+  if (isIdbAvailable()) {
+    void idbSet("memos", memos).catch(() => {
+      try {
+        localStorage.setItem("memos", JSON.stringify(memos))
+      } catch {
+        // best effort
+      }
+    })
+    return
+  }
+  try {
+    localStorage.setItem("memos", JSON.stringify(memos))
+  } catch {
+    // best effort
+  }
+}
+
 export function useMemos() {
-  const [memos, setMemos, isLoading] = useChromeStorage<Memo[]>("memos", [])
+  const { user, isReady } = useAuth()
+  const [localMemos, setLocalMemos] = useState<Memo[]>([])
+  const [cloudMemos, setCloudMemos] = useState<Memo[] | null>(null)
+  const [isLocalLoaded, setIsLocalLoaded] = useState(false)
+  const [isCloudLoaded, setIsCloudLoaded] = useState(false)
+
+  // Load local memos once on mount.
+  useEffect(() => {
+    let cancelled = false
+    void loadLocalMemos().then((stored) => {
+      if (cancelled) return
+      setLocalMemos(stored)
+      setIsLocalLoaded(true)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
+
+  // Sign-in → run migration + subscribe to Firestore.
+  useEffect(() => {
+    if (!user) {
+      setCloudMemos(null)
+      setIsCloudLoaded(false)
+      return
+    }
+    if (!isLocalLoaded) return
+    void runMigrationOnce(user.uid)
+    const unsub = subscribeMemos(user.uid, (memos) => {
+      setCloudMemos(memos)
+      setIsCloudLoaded(true)
+    })
+    return () => {
+      unsub()
+    }
+  }, [user, isLocalLoaded])
+
+  const isCloud = user !== null && cloudMemos !== null
+  const memos = isCloud ? (cloudMemos as Memo[]) : localMemos
+  const isLoading = !isReady || (user ? !isCloudLoaded : !isLocalLoaded)
 
   const addMemo = useCallback(
     (title: string, content: string) => {
@@ -124,36 +224,59 @@ export function useMemos() {
         createdAt: Date.now(),
         updatedAt: Date.now(),
       }
-      setMemos((prev) => [newMemo, ...prev])
+      if (user) {
+        void upsertMemo(user.uid, newMemo)
+      } else {
+        setLocalMemos((prev) => {
+          const next = [newMemo, ...prev]
+          saveLocalMemos(next)
+          return next
+        })
+      }
       return newMemo
     },
-    [setMemos]
+    [user],
   )
 
   const updateMemo = useCallback(
     (id: string, updates: Partial<Pick<Memo, "title" | "content">>) => {
-      setMemos((prev) =>
-        prev.map((memo) =>
-          memo.id === id
-            ? { ...memo, ...updates, updatedAt: Date.now() }
-            : memo
-        )
-      )
+      if (user) {
+        void patchMemo(user.uid, id, updates)
+      } else {
+        setLocalMemos((prev) => {
+          const next = prev.map((memo) =>
+            memo.id === id
+              ? { ...memo, ...updates, updatedAt: Date.now() }
+              : memo,
+          )
+          saveLocalMemos(next)
+          return next
+        })
+      }
     },
-    [setMemos]
+    [user],
   )
 
   const deleteMemo = useCallback(
     (id: string) => {
-      setMemos((prev) => prev.filter((memo) => memo.id !== id))
+      if (user) {
+        void removeMemo(user.uid, id)
+      } else {
+        setLocalMemos((prev) => {
+          const next = prev.filter((memo) => memo.id !== id)
+          saveLocalMemos(next)
+          return next
+        })
+      }
     },
-    [setMemos]
+    [user],
   )
 
   const getStorageInfo = useCallback(() => {
     const sizeInBytes = calculateStorageSize(memos)
-    // PWA / IndexedDB のときは事実上無制限なので警告を出さない
-    const usingChrome = hasChromeStorage()
+    // Cloud-backed and IndexedDB-backed storage are effectively unbounded;
+    // only chrome.storage.sync (local-only mode) has a meaningful quota.
+    const usingChrome = !isCloud && hasChromeStorage()
     const maxSize = usingChrome ? 8192 : Number.POSITIVE_INFINITY
     const usagePercent = usingChrome ? (sizeInBytes / maxSize) * 100 : 0
     const isNearLimit = usingChrome && usagePercent > 80
@@ -169,7 +292,7 @@ export function useMemos() {
         ? Math.max(0, maxSize - sizeInBytes)
         : Number.POSITIVE_INFINITY,
     }
-  }, [memos])
+  }, [memos, isCloud])
 
   return { memos, addMemo, updateMemo, deleteMemo, isLoading, getStorageInfo }
 }

--- a/src/lib/firebase.ts
+++ b/src/lib/firebase.ts
@@ -1,0 +1,224 @@
+// Firebase bridge for the Chrome extension build.
+//
+// Strategy:
+//   - Use chrome.identity.getAuthToken to obtain a Google OAuth2 access token
+//     for the user already signed into Chrome. No popup, no redirect — just
+//     a single native consent dialog on first use.
+//   - Convert the access token into a Firebase credential via
+//     GoogleAuthProvider.credential(null, accessToken) and signInWithCredential.
+//   - Auth persistence is in-memory only (chrome.storage backed persistence
+//     is not exposed by Firebase Auth web SDK), so we re-auth silently on
+//     every popup window load using a non-interactive getAuthToken call.
+
+import {
+  initializeApp,
+  type FirebaseApp,
+  type FirebaseOptions,
+} from "firebase/app"
+import {
+  getAuth,
+  GoogleAuthProvider,
+  signInWithCredential,
+  signOut,
+  onAuthStateChanged,
+  setPersistence,
+  inMemoryPersistence,
+  type Auth,
+  type User,
+} from "firebase/auth"
+import {
+  initializeFirestore,
+  persistentLocalCache,
+  persistentMultipleTabManager,
+  type Firestore,
+} from "firebase/firestore"
+
+interface FirebaseEnv {
+  apiKey: string
+  authDomain: string
+  projectId: string
+  appId: string
+  storageBucket?: string
+  messagingSenderId?: string
+}
+
+function readEnv(): FirebaseEnv | null {
+  const env = import.meta.env as Record<string, string | undefined>
+  const apiKey = env.VITE_FIREBASE_API_KEY
+  const authDomain = env.VITE_FIREBASE_AUTH_DOMAIN
+  const projectId = env.VITE_FIREBASE_PROJECT_ID
+  const appId = env.VITE_FIREBASE_APP_ID
+  if (!apiKey || !authDomain || !projectId || !appId) return null
+  return {
+    apiKey,
+    authDomain,
+    projectId,
+    appId,
+    storageBucket: env.VITE_FIREBASE_STORAGE_BUCKET,
+    messagingSenderId: env.VITE_FIREBASE_MESSAGING_SENDER_ID,
+  }
+}
+
+let cachedApp: FirebaseApp | null = null
+let cachedAuth: Auth | null = null
+let cachedDb: Firestore | null = null
+let configMissingWarned = false
+
+function getApp(): FirebaseApp | null {
+  if (cachedApp) return cachedApp
+  const cfg = readEnv()
+  if (!cfg) {
+    if (!configMissingWarned) {
+      console.info(
+        "[colason] Firebase config missing — running in local-only mode. " +
+          "Set VITE_FIREBASE_* in .env (root) to enable cloud sync.",
+      )
+      configMissingWarned = true
+    }
+    return null
+  }
+  const options: FirebaseOptions = {
+    apiKey: cfg.apiKey,
+    authDomain: cfg.authDomain,
+    projectId: cfg.projectId,
+    appId: cfg.appId,
+    ...(cfg.storageBucket ? { storageBucket: cfg.storageBucket } : {}),
+    ...(cfg.messagingSenderId ? { messagingSenderId: cfg.messagingSenderId } : {}),
+  }
+  cachedApp = initializeApp(options)
+  return cachedApp
+}
+
+export function isFirebaseConfigured(): boolean {
+  return readEnv() !== null
+}
+
+export function getFirebaseAuth(): Auth | null {
+  if (cachedAuth) return cachedAuth
+  const app = getApp()
+  if (!app) return null
+  cachedAuth = getAuth(app)
+  // Extension popups can be torn down between sessions; chrome.identity holds
+  // the long-lived token so we don't need IndexedDB-backed persistence.
+  void setPersistence(cachedAuth, inMemoryPersistence).catch((err) => {
+    console.warn("[colason] setPersistence failed", err)
+  })
+  return cachedAuth
+}
+
+export function getFirebaseDb(): Firestore | null {
+  if (cachedDb) return cachedDb
+  const app = getApp()
+  if (!app) return null
+  cachedDb = initializeFirestore(app, {
+    localCache: persistentLocalCache({
+      tabManager: persistentMultipleTabManager(),
+    }),
+  })
+  return cachedDb
+}
+
+function hasChromeIdentity(): boolean {
+  return (
+    typeof chrome !== "undefined" && !!chrome.identity?.getAuthToken
+  )
+}
+
+interface AuthTokenOptions {
+  interactive: boolean
+}
+
+function getAuthTokenAsync(
+  options: AuthTokenOptions,
+): Promise<string | null> {
+  return new Promise((resolve) => {
+    if (!hasChromeIdentity()) {
+      resolve(null)
+      return
+    }
+    chrome.identity.getAuthToken(options, (token) => {
+      const lastError = chrome.runtime.lastError
+      if (lastError) {
+        console.info("[colason] chrome.identity.getAuthToken:", lastError.message)
+        resolve(null)
+        return
+      }
+      // Chrome 88+: token is a string; older versions returned undefined.
+      const value =
+        typeof token === "string" && token.length > 0 ? token : null
+      resolve(value)
+    })
+  })
+}
+
+function removeCachedAuthToken(token: string): Promise<void> {
+  return new Promise((resolve) => {
+    if (!hasChromeIdentity() || !chrome.identity?.removeCachedAuthToken) {
+      resolve()
+      return
+    }
+    chrome.identity.removeCachedAuthToken({ token }, () => resolve())
+  })
+}
+
+async function exchangeForFirebaseUser(token: string): Promise<User | null> {
+  const auth = getFirebaseAuth()
+  if (!auth) return null
+  const credential = GoogleAuthProvider.credential(null, token)
+  const result = await signInWithCredential(auth, credential)
+  return result.user
+}
+
+export async function signInWithChromeIdentity(): Promise<User | null> {
+  const token = await getAuthTokenAsync({ interactive: true })
+  if (!token) return null
+  try {
+    return await exchangeForFirebaseUser(token)
+  } catch (err) {
+    // Token may be stale — drop the cache and retry once.
+    console.warn("[colason] signInWithCredential failed, clearing cache", err)
+    await removeCachedAuthToken(token)
+    const fresh = await getAuthTokenAsync({ interactive: true })
+    if (!fresh) return null
+    return await exchangeForFirebaseUser(fresh)
+  }
+}
+
+export async function silentSignInWithChromeIdentity(): Promise<User | null> {
+  const token = await getAuthTokenAsync({ interactive: false })
+  if (!token) return null
+  try {
+    return await exchangeForFirebaseUser(token)
+  } catch (err) {
+    console.warn("[colason] silent signInWithCredential failed", err)
+    await removeCachedAuthToken(token)
+    return null
+  }
+}
+
+export async function signOutUser(): Promise<void> {
+  const auth = getFirebaseAuth()
+  if (auth) {
+    try {
+      await signOut(auth)
+    } catch (err) {
+      console.warn("[colason] signOut failed", err)
+    }
+  }
+  // Also drop chrome.identity's cached token so the next sign-in is clean.
+  const token = await getAuthTokenAsync({ interactive: false })
+  if (token) {
+    await removeCachedAuthToken(token)
+  }
+}
+
+export function onAuthChanged(cb: (user: User | null) => void): () => void {
+  const auth = getFirebaseAuth()
+  if (!auth) {
+    cb(null)
+    return () => {}
+  }
+  return onAuthStateChanged(auth, (user) => cb(user))
+}
+
+export type { User }

--- a/src/lib/firestore-memos.ts
+++ b/src/lib/firestore-memos.ts
@@ -1,0 +1,111 @@
+import {
+  collection,
+  doc,
+  setDoc,
+  deleteDoc,
+  onSnapshot,
+  query,
+  orderBy,
+  serverTimestamp,
+  Timestamp,
+  type DocumentData,
+} from "firebase/firestore"
+import { getFirebaseDb } from "./firebase"
+import type { Memo } from "@/hooks/use-chrome-storage"
+
+const ROOT = "colason_users"
+const SUB = "memos"
+
+function memosCol(uid: string) {
+  const db = getFirebaseDb()
+  if (!db) return null
+  return collection(db, ROOT, uid, SUB)
+}
+
+function memoDoc(uid: string, id: string) {
+  const db = getFirebaseDb()
+  if (!db) return null
+  return doc(db, ROOT, uid, SUB, id)
+}
+
+function toMillis(value: unknown, fallback: number): number {
+  if (value instanceof Timestamp) return value.toMillis()
+  if (typeof value === "number") return value
+  return fallback
+}
+
+function fromDoc(data: DocumentData, id: string): Memo {
+  const fallback = Date.now()
+  return {
+    id,
+    title: typeof data.title === "string" ? data.title : "",
+    content: typeof data.content === "string" ? data.content : "",
+    createdAt: toMillis(data.createdAt, fallback),
+    updatedAt: toMillis(data.updatedAt, fallback),
+  }
+}
+
+export function subscribeMemos(
+  uid: string,
+  cb: (memos: Memo[]) => void,
+): () => void {
+  const col = memosCol(uid)
+  if (!col) {
+    cb([])
+    return () => {}
+  }
+  const q = query(col, orderBy("updatedAt", "desc"))
+  return onSnapshot(
+    q,
+    (snap) => {
+      const memos = snap.docs.map((d) => fromDoc(d.data(), d.id))
+      cb(memos)
+    },
+    (err) => {
+      console.error("[colason] memo subscription error", err)
+    },
+  )
+}
+
+export async function upsertMemo(
+  uid: string,
+  memo: Pick<Memo, "id" | "title" | "content" | "createdAt"> & {
+    updatedAt?: number
+  },
+): Promise<void> {
+  const ref = memoDoc(uid, memo.id)
+  if (!ref) return
+  await setDoc(
+    ref,
+    {
+      title: memo.title,
+      content: memo.content,
+      createdAt: Timestamp.fromMillis(memo.createdAt),
+      updatedAt: serverTimestamp(),
+    },
+    { merge: true },
+  )
+}
+
+export async function patchMemo(
+  uid: string,
+  id: string,
+  updates: Partial<Pick<Memo, "title" | "content">>,
+): Promise<void> {
+  const ref = memoDoc(uid, id)
+  if (!ref) return
+  await setDoc(
+    ref,
+    {
+      ...updates,
+      updatedAt: serverTimestamp(),
+    },
+    { merge: true },
+  )
+}
+
+export async function removeMemo(uid: string, id: string): Promise<void> {
+  const ref = memoDoc(uid, id)
+  if (!ref) return
+  await deleteDoc(ref)
+}

--- a/src/lib/i18n.tsx
+++ b/src/lib/i18n.tsx
@@ -87,11 +87,11 @@ const translations = {
     storageUsage: "Storage usage",
     deleteOldMemos: "Consider deleting old memos to free up space.",
 
-    // Sync (PWA only)
+    // Sync
     sync: "Sync",
     syncDisabled: "Cloud sync is not configured",
     syncDisabledHint:
-      "Set VITE_FIREBASE_* in web/.env to enable Google sign-in.",
+      "Set VITE_FIREBASE_* in .env (root) and configure manifest.json oauth2.client_id to enable Google sign-in.",
     syncSignedOut: "Local-only mode",
     syncSignedIn: "Synced to cloud",
     signInWithGoogle: "Sign in with Google",
@@ -181,11 +181,11 @@ const translations = {
     storageUsage: "使用量",
     deleteOldMemos: "古いメモを削除して容量を確保してください。",
 
-    // Sync (PWA only)
+    // Sync
     sync: "同期",
     syncDisabled: "クラウド同期は未設定です",
     syncDisabledHint:
-      "web/.env に VITE_FIREBASE_* を設定すると Google ログインが有効になります。",
+      ".env (root) に VITE_FIREBASE_* と manifest.json の oauth2.client_id を設定すると Google ログインが有効になります。",
     syncSignedOut: "ローカルのみで動作中",
     syncSignedIn: "クラウドに同期中",
     signInWithGoogle: "Google でログイン",

--- a/src/lib/migration.ts
+++ b/src/lib/migration.ts
@@ -1,0 +1,61 @@
+// One-time migration: extension's chrome.storage.sync `memos` array
+// → Firestore `colason_users/{uid}/memos/{memoId}`.
+//
+// Runs automatically when the user first signs in. Marks completion in
+// `colason_users/{uid}` so it never re-runs (even across devices).
+
+import { doc, getDoc, setDoc, serverTimestamp } from "firebase/firestore"
+import { getFirebaseDb } from "./firebase"
+import { upsertMemo } from "./firestore-memos"
+import type { Memo } from "@/hooks/use-chrome-storage"
+
+const ROOT = "colason_users"
+
+let inFlight: Promise<void> | null = null
+
+function readChromeMemos(): Promise<Memo[]> {
+  return new Promise((resolve) => {
+    if (typeof chrome === "undefined" || !chrome.storage?.sync?.get) {
+      resolve([])
+      return
+    }
+    chrome.storage.sync.get(["memos"], (result) => {
+      const value = result["memos"]
+      if (Array.isArray(value)) {
+        resolve(value as Memo[])
+      } else {
+        resolve([])
+      }
+    })
+  })
+}
+
+export function runMigrationOnce(uid: string): Promise<void> {
+  if (inFlight) return inFlight
+  inFlight = (async () => {
+    const db = getFirebaseDb()
+    if (!db) return
+    const userRef = doc(db, ROOT, uid)
+    const snap = await getDoc(userRef)
+    if (snap.exists() && snap.data()?.migrationCompletedAt) {
+      return
+    }
+    const localMemos = await readChromeMemos()
+    for (const memo of localMemos) {
+      await upsertMemo(uid, memo)
+    }
+    await setDoc(
+      userRef,
+      {
+        migrationCompletedAt: serverTimestamp(),
+        migratedCount: localMemos.length,
+        migrationSource: "chrome-extension",
+      },
+      { merge: true },
+    )
+  })().catch((err) => {
+    console.error("[colason] migration failed", err)
+    inFlight = null
+  })
+  return inFlight
+}


### PR DESCRIPTION
## Summary

Chrome 拡張版にも GCP Firestore 同期を追加。サインインは \`chrome.identity.getAuthToken\` を使い、Chrome 自体に既ログイン中の Google アカウントを流用する (PWA の \`signInWithPopup\` と違ってリダイレクトなし、初回 1 回だけネイティブ同意ダイアログ)。

サインイン成功時に \`chrome.storage.sync\` の \`memos\` を Firestore へ 1 回だけマイグレーション (\`colason_users/{uid}/migrationCompletedAt\` で重複防止)。以降は Firestore が信頼できる正、ローカルは off-line cache 用。

**Draft 理由**: マージ前に CEO 側で GCP Console + manifest.json の OAuth client_id 設定が必要。手順は下記。

## Architecture

\`\`\`
[Chrome ログイン中]
      ↓
chrome.identity.getAuthToken({interactive:true})
      ↓ accessToken
GoogleAuthProvider.credential(null, accessToken)
      ↓
signInWithCredential(auth, credential)
      ↓ Firebase user.uid
runMigrationOnce(uid):
  chrome.storage.sync.get("memos") → upsertMemo × N → migrationCompletedAt
      ↓
subscribeMemos(uid) ⇄ Firestore
\`\`\`

## ファイル

| 種別 | パス | 内容 |
|------|------|------|
| 設定 | \`manifest.json\` | \`identity\` perm、\`host_permissions\`、\`oauth2.client_id\` プレースホルダ |
| 設定 | \`.env.example\` (root) | \`VITE_FIREBASE_*\` (yomi-note-app project 流用) |
| 設定 | \`.gitignore\` | root \`.env\` / \`.env.local\` 追加 |
| lib | \`src/lib/firebase.ts\` | chrome.identity ↔ Firebase Auth bridge、Firestore init |
| lib | \`src/lib/firestore-memos.ts\` | subscribe / upsert / patch / remove |
| lib | \`src/lib/migration.ts\` | chrome.storage.sync → Firestore one-time migration |
| hook | \`src/hooks/use-auth.ts\` | Auth state + 起動時 silent sign-in |
| hook | \`src/hooks/use-chrome-storage.ts\` | \`useMemos\` を Firestore-aware に拡張 |
| UI | \`src/components/sync-control.tsx\` | Sign in/out + status |
| UI | \`src/App.tsx\` | Settings タブに SyncControl mount |
| i18n | \`src/lib/i18n.tsx\` | Sync テキストを ja/en で更新 |

## バンドルサイズ

| | Before | After | Delta |
|---|--------|-------|-------|
| main.js | 795 KB | 1,351 KB | +555 KB (Firebase Auth + Firestore) |
| background.js | 978 B | 978 B | 変化なし (Firebase 依存ゼロ) |

\`background.js\` は service worker 制約 (Firebase Auth は SW で persistence 取れない) のため Firebase 依存を持たせない設計を維持。

## CEO 側セットアップ (merge 前必須)

### 1. GCP Console で OAuth Client 作成

\`yomi-note-app\` project で:
- APIs & Services → Credentials → **Create Credentials → OAuth 2.0 Client ID**
- Application type: **Chrome Extension**
- Application ID: 拡張 ID (chrome://extensions/ で本拡張の Loaded ID)
- 作成後 \`xxxxxx.apps.googleusercontent.com\` を取得

### 2. \`.env\` 設定 (root)

\`\`\`bash
cp .env.example .env
# .env に以下をセット (web/.env と同じ値で OK):
VITE_FIREBASE_API_KEY=xxxxx
VITE_FIREBASE_APP_ID=1:1038875178392:web:xxxxx
\`\`\`

### 3. \`manifest.json\` の \`oauth2.client_id\` 置換

\`\`\`json
"oauth2": {
  "client_id": "ステップ1で取得した値",
  ...
}
\`\`\`

### 4. (推奨) \`manifest.json\` に \`key\` 追加

dev loaded と Chrome Web Store で拡張 ID を揃えるため。生成方法は [Chrome 公式](https://developer.chrome.com/docs/extensions/reference/manifest/key) を参照。設定すれば step 1 の Application ID が固定値になる。

## Test plan

- [ ] \`.env\` 設定 + \`oauth2.client_id\` 置換 → \`npm run build\` 成功
- [ ] 拡張を再 load → アイコンクリック → ウィンドウ起動
- [ ] Settings タブ → Sync セクションで "Sign in with Google" → ネイティブ同意ダイアログ → メールアドレスが表示される
- [ ] サインイン直後にローカルの memo が Firestore (\`colason_users/{uid}/memos\`) に upsert されていることを Firebase Console で確認
- [ ] 別 PC で同じ Google アカウントでサインイン → 同じ memos が表示される (リアルタイム sync)
- [ ] memo を編集 / 削除 → 別 PC にもリアルタイム反映
- [ ] Sign out → ローカルキャッシュ表示 (Firestore 接続停止)
- [ ] 2 度目のサインインで重複マイグレーションが走らない (\`migrationCompletedAt\` チェック)
- [ ] \`npm run build:web\` も成功 (alias 互換性、PR #12 互換)

## Closes

Part of #6 (Chrome 拡張側)。PWA 側は PR #12 で対応済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)